### PR TITLE
添加docker-compose部署方案

### DIFF
--- a/hertzbeat-for-dockercompose/Readme.md
+++ b/hertzbeat-for-dockercompose/Readme.md
@@ -1,0 +1,42 @@
+##  docker-compose部署方案
+
+- 如果您不想部署而是直接使用，我们提供SAAS监控云-[TanCloud探云](https://console.tancloud.cn)，即刻 **[登录注册](https://console.tancloud.cn)** 免费使用。
+- 如果你想自己本地快速部署的话，可以参考下面进行操作。
+
+### 
+
+##### 安装Docker&Docker-compose
+
+1. docker &docker-compos 安装自行百度，如果这也不会，那这个部署方式可能不适合您。
+
+##### 下载并解压部署包-hertzbeat-for-dockercompose
+
+1.进入 hertzbeat-for-dockercompose目录
+
+   `docker-compose up -d`
+
+2.创建tdengine数据库
+
+   `$ docker exec -it tdengine /bin/bash
+   root@tdengine-server:~/TDengine-server-2.4.0.4#`
+
+   创建名称为hertzbeat的数据库 进入容器后，执行 taos shell 客户端程序。
+
+   `root@tdengine-server:~/TDengine-server-2.4.0.4# taos
+   Welcome to the TDengine shell from Linux, Client Version:2.4.0.4
+   Copyright (c) 2020 by TAOS Data, Inc. All rights reserved.
+   taos>`
+
+   执行创建数据库命令
+
+   `taos> show databases;`
+
+   `taos> CREATE DATABASE hertzbeat KEEP 90 DAYS 10 BLOCKS 6 UPDATE 1;`
+
+##### 重启应用  
+
+`docker-compose restart hertzbeat`
+
+
+---
+怎么样是不是很简单，只要几分钟就可以部署完成，赶紧试试吧！

--- a/hertzbeat-for-dockercompose/conf/application.yml
+++ b/hertzbeat-for-dockercompose/conf/application.yml
@@ -1,0 +1,70 @@
+server:
+  port: 1157
+spring:
+  application:
+    name: ${HOSTNAME:@hertzbeat@}${PID}
+  profiles:
+    active: prod
+  mvc:
+    static-path-pattern: /console/**
+  resources:
+    static-locations:
+      - classpath:/dist/
+      - classpath:../dist/
+  jackson:
+    default-property-inclusion: NON_EMPTY
+
+sureness:
+  auths:
+    - digest
+    - basic
+    - jwt
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234
+    url: jdbc:mysql://mysql:3306/hertzbeat?useUnicode=true&characterEncoding=utf-8&useSSL=false
+    platform: mysql
+    hikari:
+      max-lifetime: 120000
+  jpa:
+    database: mysql
+
+  mail:
+    # 请注意邮件服务器地址：qq邮箱为 smtp.qq.com qq企业邮箱为 smtp.exmail.qq.com
+    host: smtp.qq.com
+    username: 936751812@qq.com
+    # 请注意此非邮箱账户密码 此需填写邮箱授权码
+    password: xxqzvuqbnqvbbdac
+    port: 465
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          socketFactoryClass: javax.net.ssl.SSLSocketFactory
+          ssl:
+            enable: true
+
+  thymeleaf:
+    prefix: classpath:/templates/
+    check-template-location: true
+    cache: true
+    suffix: .html
+    #encoding: UTF-8
+    #content-type: text/html
+    mode: LEGACYHTML5
+
+warehouse:
+  store:
+    td-engine:
+      enabled: true
+      driver-class-name: com.taosdata.jdbc.rs.RestfulDriver
+      url: jdbc:TAOS-RS://tdengine:6041/hertzbeat
+      username: root
+      password: taosdata

--- a/hertzbeat-for-dockercompose/conf/sql/schema.sql
+++ b/hertzbeat-for-dockercompose/conf/sql/schema.sql
@@ -1,0 +1,167 @@
+set names utf8mb4;
+drop database if exists hertzbeat;
+create database hertzbeat;
+use hertzbeat;
+
+-- ----------------------------
+-- Table structure for monitor
+-- ----------------------------
+DROP TABLE IF EXISTS  monitor ;
+CREATE TABLE  monitor
+(
+     id           bigint       not null auto_increment comment '监控ID',
+     job_id       bigint       not null comment '监控对应下发的任务ID',
+     name         varchar(100) not null comment '监控的名称',
+     app          varchar(100) not null comment '监控的类型:linux,mysql,jvm...',
+     host         varchar(100) not null comment '监控的对端host:ipv4,ipv6,域名',
+     intervals    int          not null default 600 comment '监控的采集间隔时间,单位秒',
+     status       tinyint      not null default 1 comment '监控状态 0:未监控,1:可用,2:不可用,3:不可达',
+     description  varchar(255) comment '描述备注信息',
+     creator      varchar(100) comment '创建者',
+     modifier     varchar(100) comment '最新修改者',
+     gmt_create   timestamp    default current_timestamp comment 'create time',
+     gmt_update   datetime     default current_timestamp on update current_timestamp comment 'update time',
+     primary key (id),
+     index query_index (app, host, name)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for param
+-- ----------------------------
+DROP TABLE IF EXISTS  param ;
+CREATE TABLE  param
+(
+    id           bigint       not null auto_increment comment '参数ID',
+    monitor_id   bigint       not null comment '监控ID',
+    field        varchar(100) not null comment '参数标识符',
+    value        varchar(255) comment '参数值,最大字符长度255',
+    type         tinyint      not null default 0 comment '参数类型 0:数字 1:字符串 2:加密串',
+    gmt_create   timestamp    default current_timestamp comment 'create time',
+    gmt_update   datetime     default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id),
+    index monitor_id (monitor_id),
+    unique key unique_param (monitor_id, field)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for param
+-- ----------------------------
+DROP TABLE IF EXISTS  param_define ;
+CREATE TABLE  param_define
+(
+    id           bigint           not null auto_increment comment '参数ID',
+    app          varchar(100)     not null comment '监控的类型:linux,mysql,jvm...',
+    name         varchar(100)     not null comment '参数字段对外显示名称',
+    field        varchar(100)     not null comment '参数字段标识符',
+    type         varchar(20)      not null default 'text' comment '字段类型,样式(大部分映射input标签type属性)',
+    required     boolean          not null default false comment '是否是必输项 true-必填 false-可选',
+    param_range  varchar(100)     not null comment '当type为number时,用range表示范围 eg: 0-233',
+    param_limit  tinyint unsigned not null comment '当type为text时,用limit表示字符串限制大小.最大255',
+    param_option varchar(255)     not null comment '当type为radio单选框,checkbox复选框时,option表示可选项值列表',
+    creator      varchar(100)     comment '创建者',
+    modifier     varchar(100)     comment '最新修改者',
+    gmt_create   timestamp        default current_timestamp comment 'create time',
+    gmt_update   datetime         default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id),
+    unique key unique_param_define (app, field)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- ----------------------------
+-- Table structure for alert_define
+-- ----------------------------
+DROP TABLE IF EXISTS  alert_define ;
+CREATE TABLE  alert_define
+(
+    id           bigint           not null auto_increment comment '告警定义ID',
+    app          varchar(100)     not null comment '配置告警的监控类型:linux,mysql,jvm...',
+    metric       varchar(100)     not null comment '配置告警的指标集合:cpu,memory,info...',
+    field        varchar(100)     not null comment '配置告警的指标:usage,cores...',
+    preset       boolean          not null default false comment '是否是全局默认告警，是则所有此类型监控默认关联此告警',
+    expr         varchar(255)     not null comment '告警触发条件表达式',
+    priority     tinyint          not null default 0 comment '告警级别 0:高-emergency-紧急告警-红色 1:中-critical-严重告警-橙色 2:低-warning-警告告警-黄色',
+    times        int              not null default 1 comment '触发次数,即达到触发阈值次数要求后才算触发告警',
+    enable       boolean          not null default true comment '告警阈值开关',
+    template     varchar(255)     not null comment '告警通知模板内容',
+    creator      varchar(100)     comment '创建者',
+    modifier     varchar(100)     comment '最新修改者',
+    gmt_create   timestamp        default current_timestamp comment 'create time',
+    gmt_update   datetime         default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for alert_define_monitor_bind
+-- ----------------------------
+DROP TABLE IF EXISTS  alert_define_monitor_bind ;
+CREATE TABLE  alert_define_monitor_bind
+(
+    id               bigint           not null auto_increment comment '告警定义与监控关联ID',
+    alert_define_id  bigint           not null comment '告警定义ID',
+    monitor_id       bigint           not null comment '监控ID',
+    gmt_create       timestamp        default current_timestamp comment 'create time',
+    gmt_update       datetime         default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id),
+    index index_bind (alert_define_id, monitor_id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for alert
+-- ----------------------------
+DROP TABLE IF EXISTS  alert ;
+CREATE TABLE  alert
+(
+    id               bigint           not null auto_increment comment '告警ID',
+    target           varchar(255)     not null comment '告警目标对象: 监控可用性-available 指标-app.metrics.field',
+    monitor_id       bigint           not null comment '告警对象关联的监控ID',
+    monitor_name     varchar(100)     comment '告警对象关联的监控名称',
+    alert_define_id  bigint           comment '告警关联的告警定义ID',
+    priority         tinyint          not null default 0 comment '告警级别 0:高-emergency-紧急告警-红色 1:中-critical-严重告警-橙色 2:低-warning-警告告警-黄色',
+    content          varchar(255)     not null comment '告警通知实际内容',
+    status           tinyint          not null default 0 comment '告警状态: 0-正常告警(待处理) 1-阈值触发但未达到告警次数 2-恢复告警 3-已处理',
+    times            int              not null comment '触发次数,即达到告警定义的触发阈值次数要求后才会发告警',
+    gmt_create       timestamp        default current_timestamp comment 'create time',
+    primary key (id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for notice_rule
+-- ----------------------------
+DROP TABLE IF EXISTS  notice_rule ;
+CREATE TABLE  notice_rule
+(
+    id             bigint           not null auto_increment comment '通知策略主键索引ID',
+    name           varchar(100)     not null comment '策略名称',
+    receiver_id    bigint           not null comment '消息接收人ID',
+    receiver_name  varchar(100)     not null comment '消息接收人标识',
+    enable         boolean          not null default true comment '是否启用此策略',
+    filter_all     boolean          not null default true comment '是否转发所有',
+    creator        varchar(100)     comment '创建者',
+    modifier       varchar(100)     comment '最新修改者',
+    gmt_create     timestamp        default current_timestamp comment 'create time',
+    gmt_update     datetime         default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ----------------------------
+-- Table structure for notice_receiver
+-- ----------------------------
+DROP TABLE IF EXISTS  notice_receiver ;
+CREATE TABLE  notice_receiver
+(
+    id           bigint           not null auto_increment comment '消息接收人ID',
+    name         varchar(100)     not null comment '消息接收人姓名',
+    type         tinyint          not null comment '通知信息方式: 0-手机短信 1-邮箱 2-webhook 3-微信公众号 4-企业微信机器人 5-钉钉机器人',
+    phone        varchar(100)     comment '手机号, 通知方式为手机短信时有效',
+    email        varchar(100)     comment '邮箱账号, 通知方式为邮箱时有效',
+    hook_url     varchar(255)     comment 'URL地址, 通知方式为webhook有效',
+    wechat_id    varchar(255)     comment 'openId, 通知方式为微信公众号或企业微信机器人有效',
+    access_token varchar(255)     comment '访问token, 通知方式为钉钉机器人有效',
+    creator      varchar(100)     comment '创建者',
+    modifier     varchar(100)     comment '最新修改者',
+    gmt_create   timestamp        default current_timestamp comment 'create time',
+    gmt_update   datetime         default current_timestamp on update current_timestamp comment 'update time',
+    primary key (id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8mb4;
+
+COMMIT;

--- a/hertzbeat-for-dockercompose/conf/sureness.yml
+++ b/hertzbeat-for-dockercompose/conf/sureness.yml
@@ -1,0 +1,49 @@
+## -- sureness.yml文本数据源 -- ##
+
+# 加载到匹配字典的资源,也就是需要被保护的,设置了所支持角色访问的资源
+# 没有配置的资源也默认被认证保护,但不鉴权
+# eg: /api/v1/source1===get===[role2] 表示 /api/v2/host===post 这条资源支持 role2 这一种角色访问
+# eg: /api/v1/source2===get===[] 表示 /api/v1/source2===get 这条资源不支持任何角色访问
+resourceRole:
+  - /account/auth/refresh===post===[role1,role2,role3,role4]
+
+# 需要被过滤保护的资源,不认证鉴权直接访问
+# /api/v1/source3===get 表示 /api/v1/source3===get 可以被任何人访问 无需登录认证鉴权
+excludedResource:
+  - /account/auth/**===*
+  - /===get
+  - /i18n/**===get
+  # web ui 静态资源
+  - /console/**===get
+  - /**/*.html===get
+  - /**/*.js===get
+  - /**/*.css===get
+  - /**/*.ico===get
+  - /**/*.ttf===get
+  - /**/*.png===get
+  - /**/*.gif===get
+    - /**/*.png===*
+  # swagger ui 资源
+  - /swagger-resources/**===get
+  - /v2/api-docs===get
+  - /v3/api-docs===get
+
+# 用户账户信息
+# 下面有 admin tom lili 三个账户
+# eg: admin 拥有[role1,role2]角色,密码为admin
+# eg: tom 拥有[role1,role2,role3],密码为tom@123
+# eg: lili 拥有[role1,role2],明文密码为lili, 加盐密码为1A676730B0C7F54654B0E09184448289
+account:
+  - appId: admin
+    credential: admin@123.
+    role: [role1,role2]
+  - appId: tom
+    credential: tom@123.
+    role: [role1,role2,role3]
+  - appId: lili
+    # 注意 Digest认证不支持加盐加密的密码账户
+    # 加盐加密的密码，通过 MD5(password+salt)计算
+    # 此账户的原始密码为 lili
+    credential: 1A676730B0C7F54654B0E09194448289
+    salt: 123
+    role: [role1,role2]

--- a/hertzbeat-for-dockercompose/dbdata/mysqldata/.gitignore
+++ b/hertzbeat-for-dockercompose/dbdata/mysqldata/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/hertzbeat-for-dockercompose/dbdata/taosdata/.gitignore
+++ b/hertzbeat-for-dockercompose/dbdata/taosdata/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/hertzbeat-for-dockercompose/docker-compose.yaml
+++ b/hertzbeat-for-dockercompose/docker-compose.yaml
@@ -1,0 +1,50 @@
+version: "3.7"
+
+networks:
+  heartzbeat:
+    driver: bridge
+
+services:
+  mysql:
+    image: "mysql:5.7"
+    container_name: mysql
+    hostname: mysql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      TZ: Asia/Shanghai
+      MYSQL_ROOT_PASSWORD: 1234
+    volumes:
+      - ./dbdata/mysqldata:/var/lib/mysql/
+      - ./conf/sql:/docker-entrypoint-initdb.d/
+    networks:
+      - heartzbeat
+
+  TDengine:
+    image: "tdengine/tdengine:latest"
+    container_name: tdengine
+    hostname: tdengine
+    restart: always
+    ports:
+      - "6030-6049:6030-6049"
+      - "6030-6049:6030-6049/udp"
+    volumes:
+      - ./dbdata/taosdata:/var/lib/taos/
+    networks:
+      - heartzbeat
+
+  hertzbeat:
+    image: "tancloud/hertzbeat:1.0-beta.5"
+    container_name: hertzbeat
+    hostname: hertzbeat
+    restart: always
+    environment:
+      TZ: Asia/Shanghai
+    volumes:
+      - ./conf/application.yml:/opt/hertzbeat/config/application.yml
+      - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml
+    ports:
+      - "1157:1157"
+    networks:
+      - heartzbeat


### PR DESCRIPTION
原有docker部署方案过于复杂，需要手动初始化数据等一系列操作，
故提供一种新部署方法：
采用docker-compose进行容器编排使部署更加简单只需要docker-compose up -d 一键启动mysql 、tdengine、hearzbeat等容器（已验证）

后期也可以通过commpos2k8s小工具 将docker-compos.yaml 转化为deployment 在k8s中部署（缺乏k8s 环境，待验证）