### PR TITLE
[collector]fix 采集任务超时监测线程处理异常

### DIFF
--- a/collector/src/main/java/com/usthe/collector/dispatch/CommonDispatcher.java
+++ b/collector/src/main/java/com/usthe/collector/dispatch/CommonDispatcher.java
@@ -32,7 +32,7 @@ public class CommonDispatcher implements MetricsTaskDispatch, CollectDataDispatc
     /**
      * 指标组采集任务超时时间值
      */
-    private static final long DURATION_TIME = 120_000L;
+    private static final long DURATION_TIME = 240_000L;
     /**
      * 指标组采集任务优先级队列
      */
@@ -94,7 +94,7 @@ public class CommonDispatcher implements MetricsTaskDispatch, CollectDataDispatc
             Thread.currentThread().setName("metrics-task-monitor");
             while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    // 检测每个指标组采集单元是否超时2分钟,超时则丢弃并返回异常
+                    // 检测每个指标组采集单元是否超时4分钟,超时则丢弃并返回异常
                     long deadline = System.currentTimeMillis() - DURATION_TIME;
                     for (Map.Entry<String, MetricsTime> entry : metricsTimeoutMonitorMap.entrySet()) {
                         MetricsTime metricsTime = entry.getValue();
@@ -165,7 +165,7 @@ public class CommonDispatcher implements MetricsTaskDispatch, CollectDataDispatc
                 metricsSet.forEach(metricItem -> {
                     MetricsCollect metricsCollect = new MetricsCollect(metricItem, timeout, this);
                     jobRequestQueue.addJob(metricsCollect);
-                    metricsTimeoutMonitorMap.put(job.getId() + metrics.getName(),
+                    metricsTimeoutMonitorMap.put(job.getId() + "-" + metrics.getName(),
                             new MetricsTime(System.currentTimeMillis(), metrics, timeout));
                 });
             } else {
@@ -185,7 +185,7 @@ public class CommonDispatcher implements MetricsTaskDispatch, CollectDataDispatc
                 metricsSet.forEach(metricItem -> {
                     MetricsCollect metricsCollect = new MetricsCollect(metricItem, timeout, this);
                     jobRequestQueue.addJob(metricsCollect);
-                    metricsTimeoutMonitorMap.put(job.getId() + metrics.getName(),
+                    metricsTimeoutMonitorMap.put(job.getId() + "-" + metrics.getName(),
                             new MetricsTime(System.currentTimeMillis(), metrics, timeout));
                 });
             } else {

--- a/common/src/main/java/com/usthe/common/entity/job/Job.java
+++ b/common/src/main/java/com/usthe/common/entity/job/Job.java
@@ -166,7 +166,7 @@ public class Job {
             return null;
         }
         if (!metricsSet.remove(metrics)) {
-            log.error("Job {} appId {} app {} metrics {} remove empty error in priorMetrics.",
+            log.warn("Job {} appId {} app {} metrics {} remove empty error in priorMetrics.",
                     id, monitorId, app, metrics.getName());
         }
         if (metricsSet.isEmpty()) {

--- a/warehouse/src/main/java/com/usthe/warehouse/store/TdEngineDataStorage.java
+++ b/warehouse/src/main/java/com/usthe/warehouse/store/TdEngineDataStorage.java
@@ -183,6 +183,7 @@ public class TdEngineDataStorage implements DisposableBean {
                 String createTableSql = String.format(CREATE_SUPER_TABLE_SQL, superTable, fieldSqlBuilder);
                 try {
                     assert statement != null;
+                    log.info("[tdengine-data]: create {} use sql: {}.", superTable, createTableSql);
                     statement.execute(createTableSql);
                     statement.execute(insertDataSql);
                 } catch (Exception createTableException) {


### PR DESCRIPTION
采集任务超时监测线程处理异常
导致频繁出现日志： [metrics-task-monitor] ERROR com.usthe.common.entity.job.Job Line:169 - Job 6429019850145792 appId 6429019847000064 app linux metrics memory remove empty error in priorMetrics.  
原因：超时任务监测KEY在不同地方PUT的格式不一样，导致某些已经完成的任务被误认为未完成超时，出现此问题。
解决：fix key格式不一致问题，将采集任务超时时间由120秒跳高到240秒。  