### PR TITLE
[manager]bugfix:fix linux interface metrics no instance

### DIFF
--- a/manager/src/main/resources/define/app/linux.yml
+++ b/manager/src/main/resources/define/app/linux.yml
@@ -154,6 +154,7 @@ metrics:
       # 指标信息 包括 field名称   type字段类型:0-number数字,1-string字符串   instance是否为实例主键   unit:指标单位
       - field: interface_name
         type: 1
+        instance: true
       - field: receive_bytes
         type: 0
         unit: byte

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.less
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.less
@@ -1,8 +1,0 @@
-.dynamic-button {
-  font-size: 20px;
-  margin-left: 45%;
-}
-
-.dynamic-button:hover {
-  font-size: 30px;
-}

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
@@ -16,7 +16,7 @@ import { MonitorService } from '../../../service/monitor.service';
 @Component({
   selector: 'app-monitor-modify',
   templateUrl: './monitor-edit.component.html',
-  styleUrls: ['./monitor-edit.component.less']
+  styles: []
 })
 export class MonitorEditComponent implements OnInit {
   constructor(
@@ -72,7 +72,6 @@ export class MonitorEditComponent implements OnInit {
       )
       .subscribe(message => {
         if (message.code === 0) {
-          this.paramDefines = message.data;
           this.params = [];
           this.advancedParams = [];
           this.paramDefines = [];


### PR DESCRIPTION
fix linux interface metrics no instance. 
Before, the linux interface may have some instance, but not config, it cause metrics value combine 
like this: same timesamp has two value point 
<img width="602" alt="2022-04-07 14 20 54" src="https://user-images.githubusercontent.com/24788200/162133273-61f5beb1-1f74-41d8-b465-9ede077ce115.png">

<img width="1209" alt="2022-04-07 14 20 08" src="https://user-images.githubusercontent.com/24788200/162133346-01751a23-e636-495d-a135-de9412a5ffd5.png">

Now, config the interface_name as instance. 
<img width="1245" alt="2022-04-07 14 23 10" src="https://user-images.githubusercontent.com/24788200/162133597-110c1d1a-7176-40ab-bd3c-79638e7e034e.png">


