### PR TITLE
[collector]bugfix: non-supported character set when monitor GBK oracle

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -115,6 +115,11 @@
             <artifactId>ojdbc8</artifactId>
             <version>21.5.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.nls</groupId>
+            <artifactId>orai18n</artifactId>
+            <version>21.5.0.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/manager/src/main/java/com/usthe/manager/service/impl/MonitorServiceImpl.java
+++ b/manager/src/main/java/com/usthe/manager/service/impl/MonitorServiceImpl.java
@@ -22,7 +22,6 @@ import com.usthe.manager.service.AppService;
 import com.usthe.manager.service.MonitorService;
 import com.usthe.manager.support.exception.MonitorDatabaseException;
 import com.usthe.manager.support.exception.MonitorDetectException;
-import jdk.nashorn.internal.runtime.regexp.joni.constants.Traverse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;


### PR DESCRIPTION
non-supported character set when monitor GBK oracle
need orai18n.jar to support GBK.  