### PR TITLE
[web-app]bugfix:fix side menu invisible when theme is dark

### DIFF
--- a/web-app/src/styles/theme.less
+++ b/web-app/src/styles/theme.less
@@ -33,23 +33,6 @@
   background: #ff4081;
 }
 
-
-
-.sidebar-nav .sidebar-nav__selected{
-  background: rgba(63,81,181,.15);
-  color: #3f51b5;
-}
-.sidebar-nav__sub .sidebar-nav__item{
-  color: #000000a6;
-}
-
-.sidebar-nav__open > .sidebar-nav__sub {
-  background-color: #fafafa;
-}
-.sidebar-nav__sub .sidebar-nav__item:hover{
-  background: rgba(0,0,0,.04);
-}
-
 .ant-btn-dangerous.ant-btn-primary {
   border-color: #ff4081;
   background: #ff4081;


### PR DESCRIPTION
fix side menu invisible when theme is dark, see issue #130 

<img width="334" alt="2022-05-18 09 17 08" src="https://user-images.githubusercontent.com/24788200/168937712-53bc5828-d214-4148-98e1-c87f303201ca.png">
<img width="165" alt="2022-05-18 09 17 39" src="https://user-images.githubusercontent.com/24788200/168937728-4bf4bbbc-0c1d-4581-b532-2c88319be828.png">

