### PR TITLE
[web-app]feature:update help domain from tancloud.cn to hertzbeat.com

### DIFF
--- a/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
+++ b/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
@@ -9,7 +9,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="alert"></i>
     <span>{{ 'menu.alert.dispatch' | i18n }}</span>
-    <a href="https://tancloud.cn/docs/help/alert_email" target="_blank" style="float: right; margin-right: 5%">
+    <a href="https://hertzbeat.com/docs/help/alert_email" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }}&nbsp;</span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -9,7 +9,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="alert"></i>
     <span>{{ 'menu.alert.setting' | i18n }}</span>
-    <a href="https://tancloud.cn/docs/help/alert_threshold" target="_blank" style="float: right; margin-right: 5%">
+    <a href="https://hertzbeat.com/docs/help/alert_threshold" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }}&nbsp;</span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
+++ b/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
@@ -15,7 +15,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="pie-chart"></i>
     <span>{{ 'monitor.app.' + app | i18n }} {{ 'monitors.detail' | i18n }}</span>
-    <a [href]="'https://tancloud.cn/docs/help/' + app" target="_blank" style="float: right; margin-right: 5%">
+    <a [href]="'https://hertzbeat.com/docs/help/' + app" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }} </span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
@@ -15,7 +15,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="edit"></i>
     <span>{{ 'monitors.edit' | i18n }} {{ 'monitor.app.' + monitor.app | i18n }} {{ 'monitor' | i18n }}</span>
-    <a [href]="'https://tancloud.cn/docs/help/' + monitor.app" target="_blank" style="float: right; margin-right: 5%">
+    <a [href]="'https://hertzbeat.com/docs/help/' + monitor.app" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }} </span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
+++ b/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
@@ -15,7 +15,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="plus-circle"></i>
     <span>{{ 'monitors.new' | i18n }} {{ 'monitor.app.' + monitor.app | i18n }} {{ 'monitor' | i18n }}</span>
-    <a [href]="'https://tancloud.cn/docs/help/' + monitor.app" target="_blank" style="float: right; margin-right: 5%">
+    <a [href]="'https://hertzbeat.com/docs/help/' + monitor.app" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }} </span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/app/routes/setting/tags/tags.component.html
+++ b/web-app/src/app/routes/setting/tags/tags.component.html
@@ -9,7 +9,7 @@
   <nz-breadcrumb-item>
     <i nz-icon nzType="tags"></i>
     <span>{{ 'menu.extras.tags' | i18n }}</span>
-    <a href="https://tancloud.cn/docs/help/alert_threshold" target="_blank" style="float: right; margin-right: 5%">
+    <a href="https://hertzbeat.com/docs/help/alert_threshold" target="_blank" style="float: right; margin-right: 5%">
       <span>{{ 'common.button.help' | i18n }}&nbsp;</span>
       <i nz-icon nzType="question-circle" nzTheme="outline"></i>
     </a>

--- a/web-app/src/assets/app-data.json
+++ b/web-app/src/assets/app-data.json
@@ -103,7 +103,7 @@
         },
         {
           "text": "helpCenter",
-          "externalLink": "https://tancloud.cn/docs/help/guide",
+          "externalLink": "https://hertzbeat.com/docs/help/guide",
           "target": "_blank",
           "i18n": "menu.extras.help",
           "icon": "anticon-global"


### PR DESCRIPTION
update help domain from tancloud.cn to hertzbeat.com

<img width="1088" alt="2022-06-19 19 15 21" src="https://user-images.githubusercontent.com/24788200/174478226-756cdf60-5d63-4b14-a4dc-81998575e409.png">

