### PR TITLE
[common] bugfix SnowFlakeId cannot exceed hexadecimal 0x1FFFFFFFFFFFFFF

### DIFF
--- a/common/src/main/java/com/usthe/common/util/IpDomainUtil.java
+++ b/common/src/main/java/com/usthe/common/util/IpDomainUtil.java
@@ -1,7 +1,12 @@
 package com.usthe.common.util;
 
+import lombok.extern.slf4j.Slf4j;
 import sun.net.util.IPAddressUtil;
 
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
 import java.util.regex.Pattern;
 
 /**
@@ -9,6 +14,7 @@ import java.util.regex.Pattern;
  * @author tomsun28
  * @date 2021/11/17 19:56
  */
+@Slf4j
 public class IpDomainUtil {
 
     /**
@@ -56,6 +62,32 @@ public class IpDomainUtil {
             return false;
         }
         return DOMAIN_SCHEMA.matcher(domainIp).matches();
+    }
+
+    /**
+     * get localhost IP
+     * @return ip
+     */
+    public static String getLocalhostIp() {
+        try {
+            Enumeration<NetworkInterface> allNetInterfaces = NetworkInterface.getNetworkInterfaces();
+            InetAddress ip;
+            while (allNetInterfaces.hasMoreElements()) {
+                NetworkInterface netInterface = allNetInterfaces.nextElement();
+                if (!netInterface.isLoopback() && !netInterface.isVirtual() && netInterface.isUp()) {
+                    Enumeration<InetAddress> addresses = netInterface.getInetAddresses();
+                    while (addresses.hasMoreElements()) {
+                        ip = addresses.nextElement();
+                        if (ip instanceof Inet4Address) {
+                            return ip.getHostAddress();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+        }
+        return null;
     }
 
 }

--- a/common/src/main/java/com/usthe/common/util/SnowFlakeIdGenerator.java
+++ b/common/src/main/java/com/usthe/common/util/SnowFlakeIdGenerator.java
@@ -12,7 +12,7 @@ public class SnowFlakeIdGenerator {
     private final static SnowFlakeIdWorker ID_WORKER;
 
     static {
-        ID_WORKER = new SnowFlakeIdWorker(0);
+        ID_WORKER = new SnowFlakeIdWorker();
     }
 
     public static long generateId() {

--- a/common/src/test/java/com/usthe/common/util/SnowFlakeIdGeneratorTest.java
+++ b/common/src/test/java/com/usthe/common/util/SnowFlakeIdGeneratorTest.java
@@ -13,10 +13,11 @@ class SnowFlakeIdGeneratorTest {
 
     @Test
     void generateId() {
-        // 注意 由于前端JS TS 在json解析大数会造成精度丢失 UUID 不能超过 9007199254740991（16位）
-        for (int i = 0; i < 1000; i++) {
+        // 注意 由于前端JS TS 在json解析大数会造成精度丢失 UUID 不能超过 16进制 0x1FFFFFFFFFFFFF (小于53bit)
+        // Note that because the front-end JS TS parses large numbers in json, the precision will be lost. UUID cannot exceed hexadecimal 0x1FFFFFFFFFFFFFF (less than 53bit)
+        for (int i = 0; i < 10000; i++) {
             long id = SnowFlakeIdGenerator.generateId();
-            Assertions.assertTrue(id < 9007199254740991L);
+            Assertions.assertTrue(id < 0x1FFFFFFFFFFFFFL);
         }
     }
 }


### PR DESCRIPTION
Note that due to the front-end JS TS parsing large numbers in json, precision will be lost. 
SnowFlakeId cannot exceed hexadecimal 0x1FFFFFFFFFFFFFF.