### PR TITLE
[collector] use basic auth with raw HTTP headers instead of preemptive

### DIFF
--- a/collector/src/main/java/com/usthe/collector/dispatch/DispatchConstants.java
+++ b/collector/src/main/java/com/usthe/collector/dispatch/DispatchConstants.java
@@ -52,6 +52,10 @@ public interface DispatchConstants {
      */
     String BEARER = "Bearer";
     /**
+     * Basic auth parameter
+     */
+    String BASIC = "Basic";
+    /**
      * verification method  认证方式 Basic Auth
      */
     String BASIC_AUTH = "Basic Auth";


### PR DESCRIPTION
 use basic auth with raw HTTP headers instead of preemptive mode.   
refer https://www.baeldung.com/httpclient-basic-authentication 