### PR TITLE
fix(sec): upgrade snakeyaml to 1.31

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <mysql.version>8.0.16</mysql.version>
         <h2.version>2.1.212</h2.version>
-        <snake.yaml.version>1.26</snake.yaml.version>
+        <snake.yaml.version>1.31</snake.yaml.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade snakeyaml 1.26 to 1.31 for vulnerability fix:
- [CVE-2022-38752](https://www.oscs1024.com/hd/MPS-2022-56041)
- [CVE-2022-25857](https://www.oscs1024.com/hd/MPS-2022-5144)
- [CVE-2022-38751](https://www.oscs1024.com/hd/MPS-2022-56040)