### PR TITLE
[web-app] fix echarts y-axis value tip overflow

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.html
+++ b/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.html
@@ -5,5 +5,5 @@
   [autoResize]="true"
   [loading]="loading"
   (chartInit)="onChartInit($event)"
-  style="width: 500px; height: 400px; margin-left: 20px"
+  style="width: 550px; height: 400px; margin-left: 20px"
 ></div>

--- a/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
@@ -182,6 +182,10 @@ export class MonitorDataChartComponent implements OnInit {
           }
         }
       },
+      grid: {
+        left: '2',
+        containLabel: true
+      },
       xAxis: {
         type: 'time',
         splitLine: {


### PR DESCRIPTION
before:
<img width="547" alt="2022-10-04 21 10 30" src="https://user-images.githubusercontent.com/24788200/193827738-118f756f-3e99-45bc-b95a-54c5e443250b.png">


now fix:

<img width="1187" alt="2022-10-04 21 03 30" src="https://user-images.githubusercontent.com/24788200/193827106-ed94c41f-191e-4fc0-8b0c-7e66c976223c.png">
