### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -14,10 +14,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>hertzbeat</artifactId>
         <groupId>com.usthe.tancloud</groupId>
@@ -107,7 +104,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.4.1</version>
         </dependency>
         <!-- linux ssh -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.3.3
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.3.3 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS