### PR TITLE
[web-app] fix history echarts chart tooltip only show one instance

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
@@ -164,23 +164,7 @@ export class MonitorDataChartComponent implements OnInit {
         }
       },
       tooltip: {
-        trigger: 'axis',
-        formatter: function (params: any) {
-          let time: number = params[0].value[0];
-          var date = new Date(time);
-          let seriesName = params[0].seriesName;
-          let month = (date.getMonth() + 1).toString().padStart(2, '0');
-          let day = date.getDate().toString().padStart(2, '0');
-          if (seriesName == null || seriesName == 'NULL') {
-            return `${date.getFullYear()}/${month}/${day} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()} -- ${
-              params[0].value[1]
-            }`;
-          } else {
-            return `${seriesName} ${date.getFullYear()}/${month}/${day} ${date.getHours()}:${date.getMinutes()}:${date.getSeconds()} -- ${
-              params[0].value[1]
-            }`;
-          }
-        }
+        trigger: 'axis'
       },
       grid: {
         left: '2',
@@ -190,6 +174,12 @@ export class MonitorDataChartComponent implements OnInit {
         type: 'time',
         splitLine: {
           show: false
+        },
+        axisTick: {
+          show: true
+        },
+        axisLine: {
+          onZero: false
         }
       },
       yAxis: {


### PR DESCRIPTION
before: 
<img width="645" alt="2022-10-17 23 32 34" src="https://user-images.githubusercontent.com/24788200/196219959-cf2a222b-27dc-4178-a50e-ecf735e623ea.png">

now: 
<img width="672" alt="2022-10-17 23 25 39" src="https://user-images.githubusercontent.com/24788200/196220037-52f94412-34e5-4fb3-ab37-df2e874cd047.png">
