### PR TITLE
bugfix: Fixed expression:(A | B), A and B are null, print the error log

### DIFF
--- a/collector/src/main/java/com/usthe/collector/dispatch/MetricsCollect.java
+++ b/collector/src/main/java/com/usthe/collector/dispatch/MetricsCollect.java
@@ -324,7 +324,12 @@ public class MetricsCollect implements Runnable, Comparable<MetricsCollect> {
                         }
                     }
                     try {
-                        Object objValue = expression.execute(fieldValueMap);
+                        // A | B的表达式, A和B都的value都为null, 防止打印异常
+                        List<Object> valueList = fieldValueMap.values().stream().filter(Objects::nonNull).collect(Collectors.toList());
+                        Object objValue = null;
+                        if (!valueList.isEmpty()) {
+                            objValue = expression.execute(fieldValueMap);
+                        }
                         if (objValue != null) {
                             value = String.valueOf(objValue);
                         }


### PR DESCRIPTION
calculate计算中使用了A | B的表达式，如果A和B都为null会打印错误日志，虽然不会影响功能的正常使用，仍然修复
经过测试，不会影响其他监控的使用