### PR TITLE
[OS Monitor]bugfix:Fix cpu cores and interrupt acquisition under Orac…

### DIFF
--- a/manager/src/main/resources/define/app/app-linux.yml
+++ b/manager/src/main/resources/define/app/app-linux.yml
@@ -114,7 +114,7 @@ metrics:
       username: ^_^username^_^
       password: ^_^password^_^
       timeout: ^_^timeout^_^
-      script: "LANG=C lscpu | awk -F: '/Model name/ {print $2}';awk '/processor/{core++} END{print core}' /proc/cpuinfo;uptime | sed 's/,/ /g' | awk '{for(i=NF-2;i<=NF;i++)print $i }' | xargs;vmstat 1 1 | awk 'NR==3{print $11}';vmstat 1 1 | awk 'NR==3{print $12}';vmstat 1 1 | awk 'NR==3{print $15}'"
+      script: "LANG=C lscpu | awk -F: '$1==\"Model name\" {print $2}';awk '/processor/{core++} END{print core}' /proc/cpuinfo;uptime | sed 's/,/ /g' | awk '{for(i=NF-2;i<=NF;i++)print $i }' | xargs;vmstat 1 1 | awk 'NR==3{print $11}';vmstat 1 1 | awk 'NR==3{print $12}';vmstat 1 1 | awk 'NR==3{print $15}'"
       parseType: oneRow
 
   - name: memory


### PR DESCRIPTION
Under the Oracle Linux based on the arm architecture, there is a problem in collecting cpu cores and interrupt, and it will display&nbsp

![image](https://user-images.githubusercontent.com/15188754/200483564-ef086318-fb1b-4dc2-bef7-db9f816673fe.png)


After analyzing the source code, it is found that it is a script for collecting cpu, and there are some compatibility problems

Original collection script

LANG=C lscpu | awk -F: '/Model name/ {print $2}';awk '/processor/{core++} END{print core}' /proc/cpuinfo;uptime | sed 's/,/ /g' | awk '{for(i=NF-2;i<=NF;i++)print $i }' | xargs;vmstat 1 1 | awk 'NR==3{print $11}';vmstat 1 1 | awk 'NR==3{print $12}';vmstat 1 1 | awk 'NR==3{print $15}'

Where LANG=C lscpu | awk -F: '/Model name/ {print $2}'; , because Oracle Linux will have two nodes, the Model Name and BIOS Model Name, so there are two lines of records when getting info
![image](https://user-images.githubusercontent.com/15188754/200483595-f3f073b9-b092-4578-8c77-39785d532d63.png)

I changed it to

LANG=C lscpu | awk -F: '$1=="Model name" {print $2}';awk '/processor/{core++} END{print core}' /proc/cpuinfo;uptime | sed 's/,/ /g' | awk '{for(i=NF-2;i<=NF;i++)print $i }' | xargs;vmstat 1 1 | awk 'NR==3{print $11}';vmstat 1 1 | awk 'NR==3{print $12}';vmstat 1 1 | awk 'NR==3{print $15}'

The script that gets info LANG=C lscpu | awk -F: '$1=="Model name" {print $2}';
![image](https://user-images.githubusercontent.com/15188754/200483620-3335065b-5d89-4733-9fc9-0210eb991c70.png)
