### PR TITLE
[manager] bugfix authGetToken unit test case error

### DIFF
--- a/manager/src/test/java/com/usthe/manager/controller/AccountControllerTest.java
+++ b/manager/src/test/java/com/usthe/manager/controller/AccountControllerTest.java
@@ -3,6 +3,7 @@ package com.usthe.manager.controller;
 import com.usthe.common.util.CommonConstants;
 import com.usthe.common.util.GsonUtil;
 import com.usthe.manager.pojo.dto.LoginDto;
+import com.usthe.sureness.util.JsonWebTokenUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,10 @@ class AccountControllerTest {
 
     @Test
     void authGetToken() throws Exception {
+        JsonWebTokenUtil.setDefaultSecretKey("dKhaX0csgOCTlCxq20yhmUea6H6JIpSE2Rwp"
+                + "CyaFv0bwq2Eik0jdrKUtsA6bx3sDJeFV643R"
+                + "LnfKefTjsIfJLBa2YkhEqEGtcHDTNe4CU6+9"
+                + "dKhaX0csgOCTlCxq20yhmUea6H6JIpSE2Rwp");
         LoginDto loginDto = LoginDto.builder()
                 .identifier("admin")
                 .credential("hertzbeat")


### PR DESCRIPTION
```
Error:  Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.349 s <<< FAILURE! - in com.usthe.manager.controller.AccountControllerTest
Error:  authGetToken  Time elapsed: 0.22 s  <<< ERROR!
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is com.usthe.sureness.processor.exception.ExtSurenessException: Please config your custom jwt secret. JsonWebTokenUtil.setDefaultSecretKey | sureness.jwt.secret
	at com.usthe.manager.controller.AccountControllerTest.authGetToken(AccountControllerTest.java:41)
Caused by: com.usthe.sureness.processor.exception.ExtSurenessException: Please config your custom jwt secret. JsonWebTokenUtil.setDefaultSecretKey | sureness.jwt.secret
	at com.usthe.manager.controller.AccountControllerTest.authGetToken(AccountControllerTest.java:41)
```