### PR TITLE
[doc] note: startup via source code not required mysql and tdengine env

### DIFF
--- a/home/docs/others/contributing.md
+++ b/home/docs/others/contributing.md
@@ -35,10 +35,9 @@ sidebar_label: 贡献者指南
 
 - 后端启动
 
-1. 部署启动依赖服务`MYSQL`和`TDengine`数据库
-2. 需要`maven3+`, `java8+`和`lombok`环境
-3. 修改配置文件的依赖服务地址等信息-`manager/src/main/resources/application.yml`
-4. 启动`springboot manager`服务 `manager/src/main/java/com/usthe/manager/Manager.java`
+1. 需要`maven3+`, `java11+`和`lombok`环境
+2. 修改配置文件的依赖服务地址等信息-`manager/src/main/resources/application.yml`
+3. 启动`springboot manager`服务 `manager/src/main/java/com/usthe/manager/Manager.java`
 
 - 前端启动
 


### PR DESCRIPTION
本地启动不再需要部署启动依赖服务MYSQL和TDengine数据库