### PR TITLE
[web-app] update dashboard category card ui

### DIFF
--- a/web-app/src/app/routes/alert/alert-center/alert-center.component.html
+++ b/web-app/src/app/routes/alert/alert-center/alert-center.component.html
@@ -84,31 +84,31 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1150px', y: '1240px' }"
+  [nzScroll]="{ x: '1240px', y: '1240px' }"
 >
   <thead>
     <tr>
       <th nzAlign="center" nzLeft nzWidth="4%" [(nzChecked)]="checkedAll" (nzCheckedChange)="onAllChecked($event)"></th>
-      <th nzAlign="center" nzLeft>{{ 'alert.center.target' | i18n }}</th>
-      <th nzAlign="center">{{ 'alert.center.monitor' | i18n }}</th>
-      <th nzAlign="center">{{ 'alert.center.priority' | i18n }}</th>
+      <th nzAlign="center" nzWidth="300px">{{ 'alert.center.monitor' | i18n }}</th>
+      <th nzAlign="center">{{ 'alert.center.target' | i18n }}</th>
+      <th nzAlign="center" nzWidth="120px">{{ 'alert.center.priority' | i18n }}</th>
       <th nzAlign="center">{{ 'alert.center.content' | i18n }}</th>
-      <th nzAlign="center">{{ 'alert.center.tags' | i18n }}</th>
-      <th nzAlign="center">{{ 'alert.center.status' | i18n }}</th>
+      <th nzAlign="center" nzWidth="280px">{{ 'alert.center.tags' | i18n }}</th>
+      <th nzAlign="center" nzWidth="100px">{{ 'alert.center.status' | i18n }}</th>
       <th nzAlign="center">{{ 'alert.center.time' | i18n }}</th>
       <th nzAlign="center">{{ 'common.edit' | i18n }}</th>
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let data of fixedTable.data" [ngStyle]="{ 'background-color': data.status === 0 ? '#E1E7A89B' : 'inherit' }">
+    <tr *ngFor="let data of fixedTable.data">
       <td nzAlign="center" nzLeft [nzChecked]="checkedAlertIds.has(data.id)" (nzCheckedChange)="onItemChecked(data.id, $event)"></td>
-      <td nzAlign="center" nzLeft>{{ data.target }}</td>
-      <td nzAlign="center">
+      <td nzAlign="left">
         <button nz-button nzSize="default" nzType="link" [routerLink]="['/monitors/' + data.tags?.monitorId]">
           {{ data.tags?.monitorName }}
           <span nz-icon nzType="area-chart"></span>
         </button>
       </td>
+      <td nzAlign="center">{{ data.target }}</td>
       <td nzAlign="center">
         <nz-tag *ngIf="data.priority == 0" nzColor="red">
           <i nz-icon nzType="bell" nzTheme="outline"></i>
@@ -123,14 +123,16 @@
           <span>{{ 'alert.priority.2' | i18n }}</span>
         </nz-tag>
       </td>
-      <td nzAlign="center">{{ data.content }}</td>
-      <td nzAlign="center">
+      <td nzAlign="left">{{ data.content }}</td>
+      <td nzAlign="left">
         <nz-tag style="margin-top: 2px" *ngFor="let tag of data?.tmp; let i = index">
           {{ sliceTagName(tag) }}
         </nz-tag>
       </td>
       <td nzAlign="center">
-        {{ 'alert.status.' + data.status | i18n }}
+        <nz-tag [nzColor]="data.status == 3 ? '' : 'orange'">
+          {{ 'alert.status.' + data.status | i18n }}
+        </nz-tag>
       </td>
       <td nzAlign="center">{{ data?.lastTriggerTime | date: 'YYYY-MM-dd HH:mm:ss' }}</td>
       <td nzAlign="center">

--- a/web-app/src/app/routes/dashboard/dashboard.component.html
+++ b/web-app/src/app/routes/dashboard/dashboard.component.html
@@ -11,15 +11,16 @@
         </div>
         <div nz-col nzSpan="14">
           <nz-tag class="mb-xs">
-            <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.availableSize }}</span>
+            <span>{{ 'monitor.status.available' | i18n }} </span
+            ><span style="font-weight: bolder">{{ appCountService.availableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unavailable' | i18n }} </span
-          ><span style="font-weight: bolder">{{ appCountService.unAvailableSize }}</span>
+            <span>{{ 'monitor.status.unavailable' | i18n }} </span
+            ><span style="font-weight: bolder">{{ appCountService.unAvailableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unreachable' | i18n }} </span
-          ><span style="font-weight: bolder">{{ appCountService.unReachableSize }}</span>
+            <span>{{ 'monitor.status.unreachable' | i18n }} </span
+            ><span style="font-weight: bolder">{{ appCountService.unReachableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
             <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.unManageSize }}</span>
@@ -97,10 +98,12 @@
             <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.availableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
-            <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unAvailableSize }}</span>
+            <span>{{ 'monitor.status.unavailable' | i18n }} </span
+            ><span style="font-weight: bolder">{{ appCountMid.unAvailableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
-            <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unReachableSize }}</span>
+            <span>{{ 'monitor.status.unreachable' | i18n }} </span
+            ><span style="font-weight: bolder">{{ appCountMid.unReachableSize }}</span>
           </nz-tag>
           <nz-tag class="mb-xs">
             <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unManageSize }}</span>

--- a/web-app/src/app/routes/dashboard/dashboard.component.html
+++ b/web-app/src/app/routes/dashboard/dashboard.component.html
@@ -1,105 +1,113 @@
 <div nz-row nzGutter="16" style="margin-top: 70px">
-  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md">
-    <div nz-row nzAlign="middle" class="bg-primary rounded-lg">
-      <div nz-col nzSpan="10" class="p-md text-white">
-        <div class="h2 mt0 font-weight-bold">{{ appCountService.size }}</div>
-        <p class="h5 text-nowrap mb0">
-          <i nz-icon nzType="cloud" nzTheme="outline"></i>
-          {{ 'monitor.category.service' | i18n }}
-        </p>
-      </div>
-      <div nz-col nzSpan="14" class="p-md text-white">
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.availableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
+  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md hoverCard">
+    <a [routerLink]="['/monitors']" [queryParams]="{ app: 'website' }">
+      <div nz-row nzAlign="middle" class="bg-primary rounded-lg">
+        <div nz-col nzSpan="10" class="p-md text-white">
+          <div class="h2 mt0 font-weight-bold">{{ appCountService.size }}</div>
+          <p class="h5 text-nowrap mb0">
+            <i nz-icon nzType="cloud" nzTheme="outline"></i>
+            {{ 'monitor.category.service' | i18n }}
+          </p>
+        </div>
+        <div nz-col nzSpan="14">
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.availableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
           <span>{{ 'monitor.status.unavailable' | i18n }} </span
           ><span style="font-weight: bolder">{{ appCountService.unAvailableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
+          </nz-tag>
+          <nz-tag class="mb-xs">
           <span>{{ 'monitor.status.unreachable' | i18n }} </span
           ><span style="font-weight: bolder">{{ appCountService.unReachableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.unManageSize }}</span>
-        </nz-tag>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountService.unManageSize }}</span>
+          </nz-tag>
+        </div>
       </div>
-    </div>
+    </a>
   </div>
-  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md">
-    <div nz-row nzAlign="middle" class="bg-success rounded-lg">
-      <div nz-col nzSpan="10" class="p-md text-white">
-        <div class="h2 mt0 font-weight-bold">{{ appCountDb.size }}</div>
-        <p class="h5 text-nowrap mb0">
-          <i nz-icon nzType="database" nzTheme="outline"></i>
-          {{ 'monitor.category.db' | i18n }}
-        </p>
+  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md hoverCard">
+    <a [routerLink]="['/monitors']" [queryParams]="{ app: 'mysql' }">
+      <div nz-row nzAlign="middle" class="bg-primary rounded-lg">
+        <div nz-col nzSpan="10" class="p-md text-white">
+          <div class="h2 mt0 font-weight-bold">{{ appCountDb.size }}</div>
+          <p class="h5 text-nowrap mb0">
+            <i nz-icon nzType="database" nzTheme="outline"></i>
+            {{ 'monitor.category.db' | i18n }}
+          </p>
+        </div>
+        <div nz-col nzSpan="14">
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.availableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unAvailableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unReachableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unManageSize }}</span>
+          </nz-tag>
+        </div>
       </div>
-      <div nz-col nzSpan="14">
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.availableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unAvailableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unReachableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountDb.unManageSize }}</span>
-        </nz-tag>
-      </div>
-    </div>
+    </a>
   </div>
-  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md">
-    <div nz-row nzAlign="middle" class="bg-orange rounded-lg">
-      <div nz-col nzSpan="10" class="p-md text-white">
-        <div class="h2 mt0 font-weight-bold">{{ appCountOs.size }}</div>
-        <p class="h5 text-nowrap mb0">
-          <i nz-icon nzType="windows" nzTheme="outline"></i>
-          {{ 'monitor.category.os' | i18n }}
-        </p>
+  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md hoverCard">
+    <a [routerLink]="['/monitors']" [queryParams]="{ app: 'linux' }">
+      <div nz-row nzAlign="middle" class="bg-primary rounded-lg">
+        <div nz-col nzSpan="10" class="p-md text-white">
+          <div class="h2 mt0 font-weight-bold">{{ appCountOs.size }}</div>
+          <p class="h5 text-nowrap mb0">
+            <i nz-icon nzType="windows" nzTheme="outline"></i>
+            {{ 'monitor.category.os' | i18n }}
+          </p>
+        </div>
+        <div nz-col nzSpan="14">
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.availableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unAvailableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unReachableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unManageSize }}</span>
+          </nz-tag>
+        </div>
       </div>
-      <div nz-col nzSpan="14">
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.availableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unAvailableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unReachableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountOs.unManageSize }}</span>
-        </nz-tag>
-      </div>
-    </div>
+    </a>
   </div>
-  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md">
-    <div nz-row nzAlign="middle" class="bg-magenta rounded-lg">
-      <div nz-col nzSpan="10" class="p-md text-white">
-        <div class="h2 mt0 font-weight-bold">{{ appCountMid.size }}</div>
-        <p class="h5 text-nowrap mb0">
-          <i nz-icon nzType="merge-cells" nzTheme="outline"></i>
-          {{ 'monitor.category.mid' | i18n }}
-        </p>
+  <div nz-col nzXs="24" nzSm="12" nzMd="6" class="mb-md hoverCard">
+    <a [routerLink]="['/monitors']" [queryParams]="{ app: 'kafka' }">
+      <div nz-row nzAlign="middle" class="bg-primary rounded-lg">
+        <div nz-col nzSpan="10" class="p-md text-white">
+          <div class="h2 mt0 font-weight-bold">{{ appCountMid.size }}</div>
+          <p class="h5 text-nowrap mb0">
+            <i nz-icon nzType="merge-cells" nzTheme="outline"></i>
+            {{ 'monitor.category.mid' | i18n }}
+          </p>
+        </div>
+        <div nz-col nzSpan="14">
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.availableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unAvailableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unReachableSize }}</span>
+          </nz-tag>
+          <nz-tag class="mb-xs">
+            <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unManageSize }}</span>
+          </nz-tag>
+        </div>
       </div>
-      <div nz-col nzSpan="14">
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.available' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.availableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unavailable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unAvailableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.unreachable' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unReachableSize }}</span>
-        </nz-tag>
-        <nz-tag class="mb-xs">
-          <span>{{ 'monitor.status.un-manage' | i18n }} </span><span style="font-weight: bolder">{{ appCountMid.unManageSize }}</span>
-        </nz-tag>
-      </div>
-    </div>
+    </a>
   </div>
 </div>
 

--- a/web-app/src/app/routes/dashboard/dashboard.component.less
+++ b/web-app/src/app/routes/dashboard/dashboard.component.less
@@ -95,3 +95,10 @@
     }
   }
 }
+
+.hoverCard {
+  &:hover {
+    transform: scale(104%);
+    transition: 0.2s;
+  }
+}


### PR DESCRIPTION
1. category card background color 
2. click the card to jump to the monitors

<img width="408" alt="2022-12-07 17 04 25" src="https://user-images.githubusercontent.com/24788200/206135556-0101302f-6e96-4950-8801-92b6c5428f0c.png">

After voting, we used the theme color instead of pink. 

<img width="1900" alt="2022-12-07 15 24 11" src="https://user-images.githubusercontent.com/24788200/206135894-d796cbdf-d542-4742-87e4-5137fe668709.png">

<img width="1910" alt="截屏2022-12-07 15 26 27" src="https://user-images.githubusercontent.com/24788200/206135994-8ee28b46-b140-43df-9967-f4dbb0c08e84.png">

