### PR TITLE
remove unused host bind ports

### DIFF
--- a/script/docker-compose/hertzbeat-mysql-iotdb/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     hostname: mysql
     restart: always
     ports:
-      - "3306:3306"
+      - "3306"
     environment:
       TZ: Asia/Shanghai
       MYSQL_ROOT_PASSWORD: 123456
@@ -44,8 +44,8 @@ services:
     environment:
       TZ: Asia/Shanghai
     ports:
-      - "8181:8181"
-      - "6667:6667"
+      - "8181"
+      - "6667"
     volumes:
       - ./dbdata/iotdbdata:/iotdb/data
     networks:

--- a/script/docker-compose/hertzbeat-mysql-tdengine/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     hostname: mysql
     restart: always
     ports:
-      - "3306:3306"
+      - "3306"
     environment:
       TZ: Asia/Shanghai
       MYSQL_ROOT_PASSWORD: 123456
@@ -44,8 +44,8 @@ services:
     environment:
       TZ: Asia/Shanghai
     ports:
-      - "6030-6049:6030-6049"
-      - "6030-6049:6030-6049/udp"
+      - "6030-6049"
+      - "6030-6049/udp"
     volumes:
       - ./dbdata/taosdata:/var/lib/taos/
     networks:


### PR DESCRIPTION
There is no need to mapping `mysql` and `tdengine` service ports to host. If there is a host `mysql` deamon, the port will be conflict.