### PR TITLE
[doc] fix compose doc `exec -it container name` error 

### DIFF
--- a/script/docker-compose/hertzbeat-mysql-tdengine/README.md
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/README.md
@@ -24,7 +24,7 @@
 
 3. Enter tdengine to create hertzbeat database
 
-   `$ docker exec -it tdengine /bin/bash
+   `$ docker exec -it compose-tdengine /bin/bash
    root@tdengine-server:~/TDengine-server-2.4.0.4#`
 
    Create a database named hertzbeat After entering the container, execute the taos shell client program.


### PR DESCRIPTION
docker exec -it tdengine /bin/bash
进入tdengine容器这里容器名称写错误了，最新版的容器默认名称是：compose-tdengine