### PR TITLE
fix(sec): upgrade com.google.code.gson:gson to 2.8.9

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.9</version>
         </dependency>
         <!--collect-->
         <!-- mysql -->

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.code.gson:gson 2.8.8
- [CVE-2022-25647](https://www.oscs1024.com/hd/CVE-2022-25647)


### What did I do？
Upgrade com.google.code.gson:gson from 2.8.8 to 2.8.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS