### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
+            <version>42.5.1</version>
         </dependency>
         <!-- linux ssh -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.4.1
- [CVE-2022-41946](https://www.oscs1024.com/hd/CVE-2022-41946)


### What did I do？
Upgrade org.postgresql:postgresql from 42.4.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS