### PR TITLE
Bugfix: EdDSA provider not supported

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -131,6 +131,11 @@
             <artifactId>sshd-core</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.i2p.crypto</groupId>
+            <artifactId>eddsa</artifactId>
+            <version>0.3.0</version>
+        </dependency>
         <!-- sql server -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>


### PR DESCRIPTION
当使用如下自定义配置时，Collector日志报出 EdDSA provider not supporte 错误，导致采集失败。
metrics:
  - name: storage
    priority: 0
    fields:
      - field: "total_storage"
        type: 0
        unit: 'MB'
      - field: "data_used"
        type: 0
        unit: 'MB'
      - field: "log_uesd"
        type: 0
        unit: 'MB'
      - field: "usage"
        type: 0
        unit: '%'
    aliasFields:
      - total
      - used
      - pgdata
      - pglog
    calculates:
      - total_storage=total
      - data_used=pgdata-pglog
      - log_uesd=pglog
      - usage=(used / total) * 100
    protocol: ssh
    ssh:
      host: ^_^host^_^
      port: ^_^port^_^
      username: ^_^username^_^
      password: ^_^password^_^
      timeout: ^_^timeout^_^
      script: kubectl --token='^_^token^_^' --server="https://10.96.0.1" --insecure-skip-tls-verify exec -it deploy/^_^deployment^_^ -n ^_^namespace^_^ -- df -Tm | grep overlay | awk '{print $3}';kubectl --token='^_^token^_^' --server="https://10.96.0.1" --insecure-skip-tls-verify exec -it deploy/^_^deployment^_^ -n ^_^namespace^_^ -- df -Tm | grep overlay | awk '{print $4}';kubectl --token='^_^token^_^' --server="https://10.96.0.1" --insecure-skip-tls-verify exec -it deploy/^_^deployment^_^ -n ^_^namespace^_^ -- du -d 1 -m /var/lib/postgresql/data/ | awk 'END {print}' | awk '{print $1}';kubectl --token='^_^token^_^' --server="https://10.96.0.1" --insecure-skip-tls-verify exec -it deploy/^_^deployment^_^ -n ^_^namespace^_^ -- du -d 1 -m /var/lib/postgresql/data/log | awk 'END {print}' | awk '{print $1}'
      parseType: oneRow

操作系统信息：
[root@yizhanshi207 ~]# cat /etc/os-release 
NAME="Red Hat Enterprise Linux Server"
VERSION="7.9 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="7.9"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.9 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.9"
