### PR TITLE
Added the @Column(length=2048) for special fields

### DIFF
--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/alerter/Alert.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/alerter/Alert.java
@@ -86,6 +86,7 @@ public class Alert {
             example = "linux_192.134.32.1: 534543534 cpu usage high",
             accessMode = READ_WRITE)
     @Length(max = 2048)
+    @Column(length = 2048)
     private String content;
 
     @Schema(title = "Alarm status: 0-normal alarm (to be processed) 1-threshold triggered but not reached the number of alarms 2-recovered alarm 3-processed",
@@ -119,6 +120,7 @@ public class Alert {
     @Schema(description = "告警信息标签(monitorId:xxx,monitorName:xxx)", example = "{key1:value1}", accessMode = READ_WRITE)
     @Convert(converter = JsonMapAttributeConverter.class)
     @SuppressWarnings("JpaAttributeTypeInspection")
+    @Column(length = 2048)
     private Map<String, String> tags;
 
     @Schema(title = "此条记录创建者", example = "tom", accessMode = READ_ONLY)

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/alerter/AlertDefine.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/alerter/AlertDefine.java
@@ -79,7 +79,8 @@ public class AlertDefine {
     private boolean preset;
 
     @Schema(title = "告警阈值触发条件表达式", example = "usage>90", accessMode = READ_WRITE)
-    @Length(max = 1024)
+    @Length(max = 2048)
+    @Column(length = 2048)
     private String expr;
 
     @Schema(title = "告警级别 0:高-emergency-紧急告警-红色 1:中-critical-严重告警-橙色 2:低-warning-警告告警-黄色",
@@ -98,7 +99,8 @@ public class AlertDefine {
 
     @Schema(title = "告警通知内容模版", example = "linux {monitor_name}: {monitor_id} cpu usage high",
             accessMode = READ_WRITE)
-    @Length(max = 1024)
+    @Length(max = 2048)
+    @Column(length = 2048)
     private String template;
 
     @Schema(title = "此条记录创建者", example = "tom", accessMode = READ_ONLY)

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/NoticeReceiver.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/NoticeReceiver.java
@@ -90,18 +90,21 @@ public class NoticeReceiver {
             description = "URL地址 : 通知方式为webhook有效",
             example = "https://www.tancloud.cn", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String hookUrl;
 
     @Schema(title = "openId : The notification method is valid for WeChat official account, enterprise WeChat robot or FlyBook robot",
             description = "openId : 通知方式为微信公众号，企业微信机器人或飞书机器人有效",
             example = "343432", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String wechatId;
 
     @Schema(title = "Access token : The notification method is valid for DingTalk robot",
             description = "访问token : 通知方式为钉钉机器人有效",
             example = "34823984635647", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String accessToken;
 
     @Schema(title = "Telegram bot token : The notification method is valid for Telegram Bot",
@@ -118,6 +121,7 @@ public class NoticeReceiver {
             description = "URL地址 : 通知方式为Slack有效",
             example = "https://hooks.slack.com/services/XXXX/XXXX/XXXX", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String slackWebHookUrl;
 
     @Schema(title = "Enterprise weChat message: The notification method is valid for Enterprise WeChat app message",
@@ -139,12 +143,14 @@ public class NoticeReceiver {
             description = "Discord 频道id: 通知方式为Discord有效",
             example = "1065303416030642266", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String discordChannelId;
 
     @Schema(title = "Discord bot token: The notification method is valid for Discord",
             description = "Discord 机器人Token: 通知方式为Discord有效",
             example = "MTA2NTMwMzU0ODY4Mzg4MjUzNw.xxxxx.xxxxxxx", accessMode = READ_WRITE)
     @Length(max = 300)
+    @Column(length = 300)
     private String discordBotToken;
 
     @Schema(title = "The creator of this record", description = "此条记录创建者", example = "tom",

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/NoticeRule.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/NoticeRule.java
@@ -99,6 +99,7 @@ public class NoticeRule {
     @Schema(description = "告警信息标签(monitorId:xxx,monitorName:xxx)", example = "{name: key1, value: value1}",
             accessMode = READ_WRITE)
     @Convert(converter = JsonTagListAttributeConverter.class)
+    @Column(length = 2048)
     private List<TagItem> tags;
 
     @Schema(title = "星期几,多选,全选或空则为每天 7:周日 1:周一 2:周二 3:周三 4:周四 5:周五 6:周六", example = "[0,1]", accessMode = READ_WRITE)

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Param.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Param.java
@@ -85,7 +85,7 @@ public class Param {
      */
     @Schema(title = "参数值", example = "8080", accessMode = READ_WRITE)
     @Length(max = 8126)
-    @Column(name = "`value`")
+    @Column(name = "`value`", length = 8126)
     private String value;
 
     /**

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/ParamDefine.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/ParamDefine.java
@@ -78,6 +78,7 @@ public class ParamDefine {
     @Schema(description = "参数字段显示国际化名称", example = "{zh-CN: '端口'}", accessMode = READ_WRITE)
     @Convert(converter = JsonMapAttributeConverter.class)
     @SuppressWarnings("JpaAttributeTypeInspection")
+    @Column(length = 2048)
     private Map<String, String> name;
 
     /**
@@ -142,7 +143,7 @@ public class ParamDefine {
      * value-真正值
      */
     @Schema(description = "当type为radio单选框,checkbox复选框时,option表示可选项值列表", example = "{key1,value1}", accessMode = READ_WRITE)
-    @Column(name = "param_options")
+    @Column(name = "param_options", length = 2048)
     @Convert(converter = JsonOptionListAttributeConverter.class)
     private List<Option> options;
 

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Tag.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Tag.java
@@ -63,7 +63,7 @@ public class Tag {
     private String name;
 
     @Schema(title = "Tag Value | 标签值", example = "23", accessMode = READ_WRITE)
-    @Column(name = "`value`")
+    @Column(name = "`value`", length = 2048)
     private String value;
 
     @Schema(title = "Tag Color | 标签颜色", example = "#ffff", accessMode = READ_WRITE)


### PR DESCRIPTION
## What's changed?
Issue : #870 set the special field string length when jpa auto ddl.

Changes Made:
1. Looked for all files in the repo containing @Table annotation and added @Column(length=2048) where applicable.
2. Observed `common/src/main/java/org/dromara/hertzbeat/common/entity/manager/NoticeReceiver.java` has many columns with @Length annotations with a max of 300, hence added the @Column annotation there as well with length of 300.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I haven't found any unit tests related to these changes, when ran `mvn clean install` all cases have passed.
