### PR TITLE
bugfix associated label was incorrectly deleted when deleting a monitor

### DIFF
--- a/alerter/src/main/java/org/dromara/hertzbeat/alert/dao/AlertDefineBindDao.java
+++ b/alerter/src/main/java/org/dromara/hertzbeat/alert/dao/AlertDefineBindDao.java
@@ -22,6 +22,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * AlertDefineBind database operations  数据库操作
@@ -53,7 +54,7 @@ public interface AlertDefineBindDao extends JpaRepository<AlertDefineMonitorBind
      *
      * @param monitorIds Monitoring ID List     监控ID列表
      */
-    void deleteAlertDefineMonitorBindsByMonitorIdIn(List<Long> monitorIds);
+    void deleteAlertDefineMonitorBindsByMonitorIdIn(Set<Long> monitorIds);
 
     /**
      * Query monitoring related information based on alarm definition ID

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Monitor.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/manager/Monitor.java
@@ -163,7 +163,7 @@ public class Monitor {
      *           JoinColumn  name 中间表的关联字段名称
      *                       referencedColumnName 关联表的映射字段名称
      */
-    @ManyToMany(targetEntity = Tag.class, cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @ManyToMany(targetEntity = Tag.class, cascade = CascadeType.MERGE, fetch = FetchType.EAGER)
     @JoinTable(name = "hzb_tag_monitor_bind",
         foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT),
         inverseForeignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT),

--- a/manager/src/main/java/org/dromara/hertzbeat/manager/dao/TagMonitorBindDao.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/dao/TagMonitorBindDao.java
@@ -17,34 +17,31 @@
 
 package org.dromara.hertzbeat.manager.dao;
 
-import org.dromara.hertzbeat.common.entity.manager.Tag;
+import org.dromara.hertzbeat.common.entity.manager.TagMonitorBind;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-import java.util.List;
 import java.util.Set;
 
 /**
- * tag repository
+ * TagMonitorBindDao repository
  *
  * @author tom
- * @date 2022/5/1 13:55
+ * @date 2023/4/22 11:55
  */
-public interface TagDao extends JpaRepository<Tag, Long>, JpaSpecificationExecutor<Tag> {
+public interface TagMonitorBindDao extends JpaRepository<TagMonitorBind, Long>, JpaSpecificationExecutor<TagMonitorBind> {
 
     /**
-     * delete tags by tag id
+     * delete tags bind by monitor id
      *
-     * @param ids id list
+     * @param monitorId monitorId
      */
-    void deleteTagsByIdIn(Set<Long> ids);
-
+    void deleteTagMonitorBindsByMonitorId(Long monitorId);
+    
     /**
-     * find tags by tag id
-     *
-     * @param ids id list
-     * @return tag list
+     * delete tags bind by monitor id
+     * @param monitorIds monitor list
      */
-    List<Tag> findByIdIn(Set<Long> ids);
+    void deleteTagMonitorBindsByMonitorIdIn(Set<Long> monitorIds);
     
 }

--- a/manager/src/test/java/org/dromara/hertzbeat/manager/service/MonitorServiceTest.java
+++ b/manager/src/test/java/org/dromara/hertzbeat/manager/service/MonitorServiceTest.java
@@ -13,6 +13,7 @@ import org.dromara.hertzbeat.common.entity.message.CollectRep;
 import org.dromara.hertzbeat.common.constants.CommonConstants;
 import org.dromara.hertzbeat.manager.dao.MonitorDao;
 import org.dromara.hertzbeat.manager.dao.ParamDao;
+import org.dromara.hertzbeat.manager.dao.TagMonitorBindDao;
 import org.dromara.hertzbeat.manager.pojo.dto.AppCount;
 import org.dromara.hertzbeat.manager.pojo.dto.MonitorDto;
 import org.dromara.hertzbeat.manager.service.impl.MonitorServiceImpl;
@@ -64,8 +65,7 @@ class MonitorServiceTest {
 
     @InjectMocks
     private MonitorServiceImpl monitorService = new MonitorServiceImpl(List.of());
-
-    //    @Mock(lenient = true)
+    
     @Mock
     private MonitorDao monitorDao;
 
@@ -80,6 +80,9 @@ class MonitorServiceTest {
 
     @Mock
     private AlertDefineBindDao alertDefineBindDao;
+    
+    @Mock
+    private TagMonitorBindDao tagMonitorBindDao;
     @Mock
     private CalculateAlarm calculateAlarm;
 
@@ -575,6 +578,7 @@ class MonitorServiceTest {
         Monitor existOKMonitor = Monitor.builder().jobId(id).intervals(1).app("app").name("memory").host("host").id(id).build();
         when(monitorDao.findById(id)).thenReturn(Optional.of(existOKMonitor));
         doNothing().when(alertDefineBindDao).deleteAlertDefineMonitorBindsByMonitorIdEquals(id);
+        doNothing().when(tagMonitorBindDao).deleteTagMonitorBindsByMonitorId(id);
         assertDoesNotThrow(() -> monitorService.deleteMonitor(id));
     }
 


### PR DESCRIPTION
## What's changed?

bugfix associated label was incorrectly deleted when deleting a monitor


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
