### PR TITLE
[manager]use `snakeyaml` instead of `jackson` to export monitors.

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/config/YamlMapperConfig.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/config/YamlMapperConfig.java
@@ -1,13 +1,10 @@
 package org.dromara.hertzbeat.manager.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
 /**
  * @author <a href="mailto:zqr10159@126.com">zqr10159</a>
  * Created by zqr10159 on 2023/4/20
@@ -15,23 +12,9 @@ import org.springframework.context.annotation.Primary;
 @Configuration
 public class YamlMapperConfig {
     @Bean
-    public YAMLMapper yamlMapper() {
-        YAMLMapper yamlMapper = new YAMLMapper(new YAMLFactory());
-        yamlMapper.registerModule((new JavaTimeModule()));
-        return yamlMapper;
-    }
-
-
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        //防止jackson序列化时，将LocalDateTime转换为时间戳
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        JavaTimeModule javaTimeModule = new JavaTimeModule();
-        objectMapper.registerModule(javaTimeModule);
-        return objectMapper;
-
+    public Yaml yamlMapper() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        return new Yaml(options);
     }
 }

--- a/manager/src/main/java/org/dromara/hertzbeat/manager/service/impl/YamlImExportServiceImpl.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/service/impl/YamlImExportServiceImpl.java
@@ -1,17 +1,14 @@
 package org.dromara.hertzbeat.manager.service.impl;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.yaml.snakeyaml.Yaml;
 
-import javax.annotation.Resource;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 /**
  * Configure the import and export Yaml format
@@ -22,12 +19,12 @@ import java.util.List;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class YamlImExportServiceImpl extends AbstractImExportServiceImpl{
     public static final String TYPE = "YAML";
     public static final String FILE_SUFFIX = ".yaml";
-    @Resource
-    @Qualifier("yamlMapper")
-    private YAMLMapper yamlMapper;
+
+    private final Yaml yaml;
 
 
     /**
@@ -61,13 +58,7 @@ public class YamlImExportServiceImpl extends AbstractImExportServiceImpl{
      */
     @Override
     List<ExportMonitorDTO> parseImport(InputStream is) {
-        try {
-            return yamlMapper.readValue(is, new TypeReference<>() {
-            });
-        } catch (IOException ex) {
-            log.error("import monitor failed.", ex);
-            throw new RuntimeException("import monitor failed");
-        }
+        return yaml.load(is);
     }
 
     /**
@@ -79,11 +70,6 @@ public class YamlImExportServiceImpl extends AbstractImExportServiceImpl{
      */
     @Override
     void writeOs(List<ExportMonitorDTO> monitorList, OutputStream os) {
-        try {
-            yamlMapper.writeValue(os, monitorList);
-        } catch (IOException ex) {
-            log.error("export monitor failed.", ex);
-            throw new RuntimeException("export monitor failed");
-        }
+        yaml.dump(monitorList, new OutputStreamWriter(os, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
[manager]use `snakeyaml` instead of `jakson` to export monitors.
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
