### PR TITLE
bugfix monitoring host field can not custom define in ui

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/controller/MonitorsController.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/controller/MonitorsController.java
@@ -63,15 +63,15 @@ public class MonitorsController {
     @Operation(summary = "Obtain a list of monitoring information based on query filter items",
             description = "根据查询过滤项获取监控信息列表")
     public ResponseEntity<Message<Page<Monitor>>> getMonitors(
-            @Parameter(description = "en: Monitor ID,zh: 监控ID", example = "6565463543") @RequestParam(required = false) final List<Long> ids,
-            @Parameter(description = "en: Monitor Type,zh: 监控类型", example = "linux") @RequestParam(required = false) final String app,
-            @Parameter(description = "en: Monitor Name,zh: 监控名称，模糊查询", example = "linux-127.0.0.1") @RequestParam(required = false) final String name,
-            @Parameter(description = "en: Monitor Host,zh: 监控Host，模糊查询", example = "127.0.0.1") @RequestParam(required = false) final String host,
-            @Parameter(description = "en: Monitor Status,zh: 监控状态 0:未监控,1:可用,2:不可用,3:不可达,4:挂起,9:全部状态", example = "1") @RequestParam(required = false) final Byte status,
-            @Parameter(description = "en: Sort Field,default id,zh: 排序字段，默认更新时间", example = "name") @RequestParam(defaultValue = "gmtUpdate") final String sort,
-            @Parameter(description = "en: Sort by,zh: 排序方式，asc:升序，desc:降序", example = "desc") @RequestParam(defaultValue = "desc") final String order,
-            @Parameter(description = "en: List current page,zh: 列表当前分页", example = "0") @RequestParam(defaultValue = "0") int pageIndex,
-            @Parameter(description = "en: Number of list pagination,zh: 列表分页数量", example = "8") @RequestParam(defaultValue = "8") int pageSize) {
+            @Parameter(description = "Monitor ID | 监控ID", example = "6565463543") @RequestParam(required = false) final List<Long> ids,
+            @Parameter(description = "Monitor Type | 监控类型", example = "linux") @RequestParam(required = false) final String app,
+            @Parameter(description = "Monitor Name | 监控名称，模糊查询", example = "linux-127.0.0.1") @RequestParam(required = false) final String name,
+            @Parameter(description = "Monitor Host | 监控Host，模糊查询", example = "127.0.0.1") @RequestParam(required = false) final String host,
+            @Parameter(description = "Monitor Status | 监控状态 0:未监控,1:可用,2:不可用,3:不可达,4:挂起,9:全部状态", example = "1") @RequestParam(required = false) final Byte status,
+            @Parameter(description = "Sort Field | 排序字段", example = "name") @RequestParam(defaultValue = "gmtCreate") final String sort,
+            @Parameter(description = "Sort by | 排序方式，asc:升序，desc:降序", example = "desc") @RequestParam(defaultValue = "desc") final String order,
+            @Parameter(description = "List current page | 列表当前分页", example = "0") @RequestParam(defaultValue = "0") int pageIndex,
+            @Parameter(description = "Number of list pagination | 列表分页数量", example = "8") @RequestParam(defaultValue = "8") int pageSize) {
         Specification<Monitor> specification = (root, query, criteriaBuilder) -> {
             List<Predicate> andList = new ArrayList<>();
             if (ids != null && !ids.isEmpty()) {

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
@@ -36,7 +36,7 @@
     <form nz-form #editForm="ngForm">
       <nz-form-item>
         <nz-form-label [nzSpan]="7" nzFor="host" nzRequired="true" [nzTooltipTitle]="'monitor.host.tip' | i18n">
-          {{ 'monitor.host' | i18n }}
+          {{ hostName ? hostName : ('monitor.host' | i18n) }}
         </nz-form-label>
         <nz-form-control [nzSpan]="8" [nzErrorTip]="'validation.required' | i18n">
           <input [(ngModel)]="monitor.host" nz-input name="host" type="text" id="host" required [placeholder]="'monitor.host.tip' | i18n" />

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
@@ -34,6 +34,7 @@ export class MonitorEditComponent implements OnInit {
   ) {}
 
   paramDefines!: ParamDefine[];
+  hostName!: string;
   params!: Param[];
   advancedParamDefines!: ParamDefine[];
   advancedParams!: Param[];
@@ -119,6 +120,9 @@ export class MonitorEditComponent implements OnInit {
             } else {
               this.params.push(param);
               this.paramDefines.push(define);
+            }
+            if (define.field == 'host' && define.type == 'host' && define.name != `monitor.app.${this.monitor.app}.param.${define.field}`) {
+              this.hostName = define.name;
             }
           });
         } else {

--- a/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
+++ b/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
@@ -36,7 +36,7 @@
     <form nz-form #newForm="ngForm">
       <nz-form-item>
         <nz-form-label [nzSpan]="7" nzFor="host" nzRequired="true" [nzTooltipTitle]="'monitor.host.tip' | i18n">
-          {{ 'monitor.host' | i18n }}
+          {{ hostName ? hostName : ('monitor.host' | i18n) }}
         </nz-form-label>
         <nz-form-control [nzSpan]="8" [nzErrorTip]="'validation.required' | i18n">
           <input

--- a/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.ts
@@ -21,6 +21,7 @@ import { TagService } from '../../../service/tag.service';
 })
 export class MonitorNewComponent implements OnInit {
   paramDefines!: ParamDefine[];
+  hostName!: string;
   params!: Param[];
   advancedParamDefines!: ParamDefine[];
   advancedParams!: Param[];
@@ -96,6 +97,9 @@ export class MonitorNewComponent implements OnInit {
             } else {
               this.params.push(param);
               this.paramDefines.push(define);
+            }
+            if (define.field == 'host' && define.type == 'host' && define.name != `monitor.app.${this.monitor.app}.param.${define.field}`) {
+              this.hostName = define.name;
             }
           });
         } else {


### PR DESCRIPTION
## What's changed?

- bugfix monitoring host field can not custom define in ui
- change query monitoring list default sort field to `gmtCreate`


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
