### PR TITLE
[collector] fix dispatch concurrency bug

### DIFF
--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Job.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Job.java
@@ -217,7 +217,11 @@ public class Job {
             if (priorMetrics.isEmpty()) {
                 return null;
             }
-            return priorMetrics.peek();
+            //return priorMetrics.peek();
+            Set<Metrics> source = priorMetrics.peek();
+            Set<Metrics> target = new HashSet<>();
+            target.addAll(source);
+            return target;
         } else {
             return Collections.emptySet();
         }

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Job.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Job.java
@@ -217,11 +217,8 @@ public class Job {
             if (priorMetrics.isEmpty()) {
                 return null;
             }
-            //return priorMetrics.peek();
             Set<Metrics> source = priorMetrics.peek();
-            Set<Metrics> target = new HashSet<>();
-            target.addAll(source);
-            return target;
+            return new HashSet<>(source);
         } else {
             return Collections.emptySet();
         }


### PR DESCRIPTION
## What's changed?

org.dromara.hertzbeat.collector.dispatch.CommonDispatcher 244行
`metricsSet.forEach(metricItem -> {});`
和
org.dromara.hertzbeat.common.entity.job.Jon 211 行
` if (!metricsSet.remove(metrics)) {`
会出现并发错误。

迭代时出现异常，导致监控轮训任务终止。
`
java.util.ConcurrentModificationException: null
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1510)
        at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1533)
        at java.base/java.lang.Iterable.forEach(Iterable.java:74)
        at com.usthe.collector.dispatch.CommonDispatcher.dispatchCollectData(CommonDispatcher.java:244)
`
在Job的getNextCollectMetrics返回一个新的HashSet，避免出现这个问题。

该问题在监控Mysql服务的时候能稳定重现出现。

