### PR TITLE
Fixed Carousel Overflow on homepage and made it responsive

### DIFF
--- a/home/src/pages/components/LogoCarousel.js
+++ b/home/src/pages/components/LogoCarousel.js
@@ -10,15 +10,32 @@ const iconCommonUrl = '/img/icons/'
 // const cdnUrl = '/img/icons/'
 
 var settings = {
-    dots: false,
     infinite: true,
     speed: 1200,
     slidesToShow: 6,
     slidesToScroll: 1,
     autoplay: true,
-    autoplaySpeed: 800,
+    autoplaySpeed: 1000,
     rows: 1,
-    vertical: false
+    responsive : [
+        {
+            breakpoint : 1024,
+            settings : {
+                slidesToShow : 2.75,
+                slidesToScroll : 3,
+                speed : 2000,
+                infinite : true,
+            },
+        },
+        {
+            breakpoint : 480,
+            settings : {
+                speed : 2000,
+                slidesToShow : 0.75,
+                slidesToScroll : 1,
+            }
+        }
+    ],
 };
 
 export default class LogoCarousel extends React.Component {


### PR DESCRIPTION
## What's changed?
The Logo and Dromara Friends Carousel was breaking for mobile and tablet devices. check https://hertzbeat.com/
I made the nesccessary changes to make the carousel responsive. 
<!-- Describe Your PR Here -->
## Before the PR : 
![image](https://github.com/dromara/hertzbeat/assets/100678386/6be55f28-1c4a-4868-8c5d-7116a8151d3f)
![image](https://github.com/dromara/hertzbeat/assets/100678386/8d0db326-4399-4aa7-8510-9fa24698089b)

## Carousels after PR gets merged : 
[Screencast from 21-05-23 02:08:48 PM IST.webm](https://github.com/dromara/hertzbeat/assets/100678386/f1814fbf-f190-4d32-a157-ad0d54838bdb)


## Checklist
- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
