### PR TITLE
add sshd server when build hertzbeat docker image

### DIFF
--- a/script/docker/server/Dockerfile
+++ b/script/docker/server/Dockerfile
@@ -2,12 +2,16 @@ FROM openjdk:11.0.16-jre-slim-buster
 
 MAINTAINER tancloud "tomsun28@outlook.com"
 
+# Install SSH
+RUN apt-get update && apt-get install -y openssh-server 
+RUN mkdir /var/run/sshd
+
 ADD hertzbeat-1.3.1.tar /opt/
 
 ENV TZ=Asia/Shanghai
 #ENV LANG=zh_CN.UTF-8
 
-EXPOSE 1157
+EXPOSE 1157 22
 
 WORKDIR /opt/hertzbeat/
 


### PR DESCRIPTION
## What's changed?

I added he sshd server when building the hertzbeat docker image. For issue "#982"

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
