### PR TITLE
Failed to fix the WeWork Robot sending messages

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/pojo/dto/WeWorkWebHookDto.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/pojo/dto/WeWorkWebHookDto.java
@@ -43,7 +43,7 @@ public class WeWorkWebHookDto {
     /**
      * 文本格式
      */
-    private static final String TEXT = "TEXT";
+    private static final String TEXT = "text";
 
     /**
      * 消息类型


### PR DESCRIPTION
## What's changed?

解决企业微信机器人消息类型仅支持小写，大写企微会报错，返回    "errcode": 40008


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
