### PR TITLE
support quay.io as hertzbeat docker images repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,13 @@
 
 ##### 1：Install quickly via docker   
 
-1. Just one command to get started: `docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat` 
+1. Just one command to get started:
+
+```docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat```
+
+```or use quay.io (if dockerhub network connect timeout)```
+
+```docker run -d -p 1157:1157 --name hertzbeat quay.io/tancloud/hertzbeat```
 
 2. Access `localhost:1157` to start, default account: `admin/hertzbeat`  
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -99,7 +99,11 @@
 
 1. `docker` 环境仅需一条命令即可开始     
 
-`docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat` 
+```docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat```
+
+```或者使用 quay.io (若 dockerhub 网络链接超时)```
+
+```docker run -d -p 1157:1157 --name hertzbeat quay.io/tancloud/hertzbeat```
 
 2. 浏览器访问 `localhost:1157` 即可开始，默认账号密码 `admin/hertzbeat`
 

--- a/home/docs/start/docker-deploy.md
+++ b/home/docs/start/docker-deploy.md
@@ -16,9 +16,14 @@ sidebar_label: Install via Docker
    ```
 
 2. pull HertzBeat Docker mirror  
-   you can look up the mirror version TAG in [official mirror repository](https://hub.docker.com/r/tancloud/hertzbeat/tags)     
-   ``` 
+   you can look up the mirror version TAG in [dockerhub mirror repository](https://hub.docker.com/r/tancloud/hertzbeat/tags)  
+   or in [quay.io mirror repository](https://quay.io/repository/tancloud/hertzbeat)     
+   ```shell
    $ docker pull tancloud/hertzbeat   
+   ```
+   or  
+   ```shell
+   $ docker pull quay.io/tancloud/hertzbeat
    ```
 
 3. Mounted HertzBeat configuration file (optional)    
@@ -60,7 +65,7 @@ $ docker run -d -p 1157:1157 \
    - `-v /opt/application.yml:/opt/hertzbeat/config/application.yml`  : (optional, if you don't have a need, just delete it) Mount the local configuration file into the container which has been modified in the previous step, namely using the local configuration file to cover container configuration file.    
    - `-v /opt/sureness.yml:/opt/hertzbeat/config/sureness.yml`  : (optional, if you don't have a need, just delete it) Mount account configuration file modified in the previous step into the container. Delete this command parameters if no needs.  
    - `--name hertzbeat` : Naming container name hertzbeat 
-   - `tancloud/hertzbeat` : Use the pulled latest HertzBeat official application mirror to start the container. Version can be looked up in [official mirror repository](https://hub.docker.com/r/tancloud/hertzbeat/tags)   
+   - `tancloud/hertzbeat` : Use the pulled latest HertzBeat official application mirror to start the container. **Use `quay.io/tancloud/hertzbeat` instead if you pull `quay.io` docker image.**     
 
 6. Begin to explore HertzBeat  
 

--- a/home/docs/start/quickstart.md
+++ b/home/docs/start/quickstart.md
@@ -15,7 +15,13 @@ sidebar_label: Quick Start
 
 ##### 1：Install quickly via docker
 
-1. Just one command to get started: `docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat`
+1. Just one command to get started:
+
+```docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat```
+
+```or use quay.io (if dockerhub network connect timeout)```
+
+```docker run -d -p 1157:1157 --name hertzbeat quay.io/tancloud/hertzbeat```
 
 2. Access `localhost:1157` to start, default account: `admin/hertzbeat`
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/docker-deploy.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/docker-deploy.md
@@ -18,10 +18,15 @@ sidebar_label: Docker方式部署
    ```
 
 2. 拉取HertzBeat Docker镜像   
-   镜像版本TAG可查看[官方镜像仓库](https://hub.docker.com/r/tancloud/hertzbeat/tags)     
+   镜像版本TAG可查看 [dockerhub 官方镜像仓库](https://hub.docker.com/r/tancloud/hertzbeat/tags)     
+   或者使用 [quay.io 镜像仓库](https://quay.io/repository/tancloud/hertzbeat)
 
-   ``` shell
+   ```shell
    $ docker pull tancloud/hertzbeat   
+   ```
+   若网络超时或者使用
+   ```shell
+   $ docker pull quay.io/tancloud/hertzbeat
    ```
 
 3. 部署HertzBeat您可能需要掌握的几条命令
@@ -96,7 +101,7 @@ $ docker run -d -p 1157:1157 \
      $ docker update --restart=always hertzbeat
      ```
 
-   - `tancloud/hertzbeat` : 使用拉取最新的的HertzBeat官方发布的应用镜像来启动容器,版本可查看[官方镜像仓库](https://hub.docker.com/r/tancloud/hertzbeat/tags)   
+   - `tancloud/hertzbeat` : 使用拉取最新的的HertzBeat官方发布的应用镜像来启动容器,**若使用`quay.io`镜像需用参数`quay.io/tancloud/hertzbeat`代替。**   
 
 7. 开始探索HertzBeat  
    浏览器访问 http://ip:1157/ 即可开始探索使用HertzBeat，默认账户密码 admin/hertzbeat。  

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/quickstart.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/quickstart.md
@@ -63,7 +63,7 @@ $ docker run -d -p 6667:6667 -p 31999:31999 -p 8181:8181 \
 
 2. 浏览器访问 `localhost:1157` 即可开始，默认账号密码 `admin/hertzbeat`
 
-更多配置详细步骤参考 [通过Docker方式安装HertzBeat](docker-deploy.md) 
+更多配置详细步骤参考 [通过Docker方式安装HertzBeat](docker-deploy) 
 
 #### 方式二：通过安装包安装    
 
@@ -73,7 +73,7 @@ $ docker run -d -p 6667:6667 -p 31999:31999 -p 8181:8181 \
 4. 部署启动 `$ ./startup.sh `
 5. 浏览器访问 `localhost:1157` 即可开始，默认账号密码 `admin/hertzbeat`
 
-更多配置详细步骤参考 [通过安装包安装HertzBeat](package-deploy.md) 
+更多配置详细步骤参考 [通过安装包安装HertzBeat](package-deploy) 
 
 #### 方式三：本地代码启动   
 1. 此为前后端分离项目，本地代码调试需要分别启动后端工程manager和前端工程web-app

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/quickstart.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/quickstart.md
@@ -55,7 +55,11 @@ $ docker run -d -p 6667:6667 -p 31999:31999 -p 8181:8181 \
 
 1. `docker` 环境仅需一条命令即可开始
 
-`docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat`
+```docker run -d -p 1157:1157 --name hertzbeat tancloud/hertzbeat```
+
+```或者使用 quay.io (若 dockerhub 网络链接超时)```
+
+```docker run -d -p 1157:1157 --name hertzbeat quay.io/tancloud/hertzbeat```
 
 2. 浏览器访问 `localhost:1157` 即可开始，默认账号密码 `admin/hertzbeat`
 

--- a/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
@@ -56,7 +56,9 @@ resourceRole:
 excludedResource:
   - /api/account/auth/**===*
   - /api/i18n/**===get
+  - /api/metrics===get
   - /api/apps/hierarchy===get
+  - /actuator/**===get
   # web ui 前端静态资源
   - /===get
   - /dashboard/**===get
@@ -79,6 +81,8 @@ excludedResource:
   - /swagger-resources/**===get
   - /v2/api-docs===get
   - /v3/api-docs===get
+  # h2 database
+  - /h2-console/**===*
 
 # 用户账户信息
 # 下面有 admin tom lili 三个账户

--- a/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
@@ -56,7 +56,9 @@ resourceRole:
 excludedResource:
   - /api/account/auth/**===*
   - /api/i18n/**===get
+  - /api/metrics===get
   - /api/apps/hierarchy===get
+  - /actuator/**===get
   # web ui 前端静态资源
   - /===get
   - /dashboard/**===get
@@ -79,6 +81,8 @@ excludedResource:
   - /swagger-resources/**===get
   - /v2/api-docs===get
   - /v3/api-docs===get
+  # h2 database
+  - /h2-console/**===*
 
 # 用户账户信息
 # 下面有 admin tom lili 三个账户

--- a/script/docker-compose/hertzbeat-postgresql-iotdb/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-postgresql-iotdb/conf/sureness.yml
@@ -56,7 +56,9 @@ resourceRole:
 excludedResource:
   - /api/account/auth/**===*
   - /api/i18n/**===get
+  - /api/metrics===get
   - /api/apps/hierarchy===get
+  - /actuator/**===get
   # web ui 前端静态资源
   - /===get
   - /dashboard/**===get
@@ -79,6 +81,8 @@ excludedResource:
   - /swagger-resources/**===get
   - /v2/api-docs===get
   - /v3/api-docs===get
+  # h2 database
+  - /h2-console/**===*
 
 # 用户账户信息
 # 下面有 admin tom lili 三个账户


### PR DESCRIPTION
## What's changed?

support quay.io as hertzbeat docker images repository
due dockerhub network timeout 

https://quay.io/repository/tancloud/hertzbeat?tab=info

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
