### PR TITLE
bugfix linux shell echo field value is too long and causes a line break

### DIFF
--- a/manager/src/main/resources/define/app-linux.yml
+++ b/manager/src/main/resources/define/app-linux.yml
@@ -340,7 +340,7 @@ metrics:
       password: ^_^password^_^
       privateKey: ^_^privateKey^_^
       timeout: ^_^timeout^_^
-      script: df -m | tail -n +2 | awk 'BEGIN{ print "filesystem used available usage mounted"} {print $1,$3,$4,$5,$6}'
+      script: df -mP | tail -n +2 | awk 'BEGIN{ print "filesystem used available usage mounted"} {print $1,$3,$4,$5,$6}'
       parseType: multiRow
 
   - name: top_cpu_process


### PR DESCRIPTION
增加参数“P”，为了输出结果以长格式显示

## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
