### PR TITLE
remove auto replace uri special char in http request params

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -512,7 +512,7 @@ public class HttpCollectImpl extends AbstractCollect {
         if (params != null && !params.isEmpty()) {
             for (Map.Entry<String, String> param : params.entrySet()) {
                 if (StringUtils.hasText(param.getValue())) {
-                    requestBuilder.addParameter(param.getKey(),param.getValue());
+                    requestBuilder.addParameter(param.getKey(), param.getValue());
                 }
             }
         }

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -512,8 +512,7 @@ public class HttpCollectImpl extends AbstractCollect {
         if (params != null && !params.isEmpty()) {
             for (Map.Entry<String, String> param : params.entrySet()) {
                 if (StringUtils.hasText(param.getValue())) {
-                    requestBuilder.addParameter(CollectUtil.replaceUriSpecialChar(param.getKey()),
-                            CollectUtil.replaceUriSpecialChar(param.getValue()));
+                    requestBuilder.addParameter(param.getKey(),param.getValue());
                 }
             }
         }


### PR DESCRIPTION

## What's changed?

【移除 requestBuilder在添加params的时候使用的replaceUriSpecialChar功能，因为replaceUriSpecialChar导致params错误】
## Checklist

