### PR TITLE
bugfix common alarm do not need monitorId tag existed

### DIFF
--- a/alerter/src/main/java/org/dromara/hertzbeat/alert/reduce/AlarmCommonReduce.java
+++ b/alerter/src/main/java/org/dromara/hertzbeat/alert/reduce/AlarmCommonReduce.java
@@ -35,16 +35,16 @@ public class AlarmCommonReduce {
 	    Map<String, String> tags = alert.getTags();
 	    String monitorIdStr = tags.get(CommonConstants.TAG_MONITOR_ID);
 	    if (monitorIdStr == null) {
-		    log.error("alert tags monitorId can not be null: {}.", alert);
-		    return;
-	    }
-	    long monitorId = Long.parseLong(monitorIdStr);
-	    List<Tag> tagList = alertMonitorDao.findMonitorIdBindTags(monitorId);
-		tagList.forEach(tag -> {
-			if (!tags.containsKey(tag.getName())) {
-				tags.put(tag.getName(), tag.getValue());
-			}
-		});
+            log.debug("receiver extern alarm message: {}", alert);
+	    } else {
+            long monitorId = Long.parseLong(monitorIdStr);
+            List<Tag> tagList = alertMonitorDao.findMonitorIdBindTags(monitorId);
+            tagList.forEach(tag -> {
+                if (!tags.containsKey(tag.getName())) {
+                    tags.put(tag.getName(), tag.getValue());
+                }
+            });   
+        }
 		// converge -> silence
 	    if (alarmConvergeReduce.filterConverge(alert) && alarmSilenceReduce.filterSilence(alert)) {
 			dataQueue.sendAlertsData(alert);


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

bugfix common alarm do not need monitorId tag existed

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
