### PR TITLE
[manager] fix: can query by tags when tagValue is null

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/controller/MonitorsController.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/controller/MonitorsController.java
@@ -99,11 +99,11 @@ public class MonitorsController {
 			if (StringUtils.hasText(tag)) {
 				String[] tagArr = tag.split(":");
 				String tagName = tagArr[0];
-				String tagValue = tagArr[1];
 				ListJoin<Monitor, org.dromara.hertzbeat.common.entity.manager.Tag> tagJoin = root
 						.join(root.getModel()
 								.getList("tags", org.dromara.hertzbeat.common.entity.manager.Tag.class), JoinType.LEFT);
 				if (tagArr.length == TAG_LENGTH) {
+					String tagValue = tagArr[1];
 					andList.add(criteriaBuilder.equal(tagJoin.get("name"), tagName));
 					andList.add(criteriaBuilder.equal(tagJoin.get("value"), tagValue));
 				} else {


### PR DESCRIPTION
## What's changed?

Fix bugs that cannot query minotrs when tagValue is null


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
