### PR TITLE
feature:monitor brearer token api, ignore letter case to comparison

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -543,7 +543,7 @@ public class HttpCollectImpl extends AbstractCollect {
         // 判断是否使用Bearer Token认证
         if (httpProtocol.getAuthorization() != null) {
             HttpProtocol.Authorization authorization = httpProtocol.getAuthorization();
-            if (DispatchConstants.BEARER_TOKEN.equals(authorization.getType())) {
+            if (DispatchConstants.BEARER_TOKEN.equalsIgnoreCase(authorization.getType())) {
                 // 若使用 将token放入到header里面
                 String value = DispatchConstants.BEARER + " " + authorization.getBearerTokenToken();
                 requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, value);


### PR DESCRIPTION
## What's changed?
feature:monitor brearer token api, ignore letter case to comparison
change: Monitor the configured interface to determine whether to write the bearer token value in the header, where app hertzbeat is required_ Compare the type configuration value in the HTTP authorization in token. yml with the default value of backend dispatchConstants. This modification is to ignore case in this comparison to avoid typing in the yml file that does not conform to the initial uppercase format and cannot match


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
