### PR TITLE
replace obsolete `registry.npm.taobao.org` to`registry.npmmirror.com`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Even small corrections to typos are very welcome :)
 1. Need `nodejs npm angular-cli` environment
 2. Install yarn: `npm install -g yarn`   
 3. Execute under the front-end project directory web-app: `yarn install`
-4. Install angular-cli globally: `npm install -g @angular/cli@14 --registry=https://registry.npm.taobao.org`
+4. Install angular-cli globally: `npm install -g @angular/cli@14 --registry=https://registry.npmmirror.com`
 5. After the local backend is started, start the local frontend in the web-app directory: `ng serve --open`
 6. Browser access to localhost:4200 to start   
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ Public WeChat: `tancloudtech`
 1. 需要`nodejs npm angular-cli`环境
 2. 安装yarn `npm install -g yarn`
 3. 在前端工程目录web-app下执行 `yarn install`
-4. 全局安装angular-cli `npm install -g @angular/cli@14 --registry=https://registry.npm.taobao.org`
+4. 全局安装angular-cli `npm install -g @angular/cli@14 --registry=https://registry.npmmirror.com`
 5. 待本地后端启动后，在web-app目录下启动本地前端 `ng serve --open`
 6. 浏览器访问 localhost:4200 即可开始，默认账号密码 admin/hertzbeat
 


### PR DESCRIPTION
## What's changed?

replace obsolete `registry.npm.taobao.org` to`registry.npmmirror.com`


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
