### PR TITLE
bugfix old version monitor alert has no monitor name

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/component/alerter/impl/DbAlertStoreHandlerImpl.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/component/alerter/impl/DbAlertStoreHandlerImpl.java
@@ -53,8 +53,11 @@ final class DbAlertStoreHandlerImpl implements AlertStoreHandler {
             long monitorId = Long.parseLong(monitorIdStr);
             Monitor monitor = monitorService.getMonitor(monitorId);
             if (monitor == null) {
-                log.warn("Dispatch alarm the monitorId: {} not existed, ignored.", monitorId);
+                log.warn("Dispatch alarm the monitorId: {} not existed, ignored. target: {}.", monitorId, alert.getTarget());
                 return;
+            }
+            if (!tags.containsKey(CommonConstants.TAG_MONITOR_NAME)) {
+                tags.put(CommonConstants.TAG_MONITOR_NAME, monitor.getName());
             }
             if (monitor.getStatus() == CommonConstants.UN_MANAGE_CODE) {
                 // When monitoring is not managed, ignore and silence its alarm messages


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

bugfix old version monitor alert has no monitor name

fix https://gitee.com/dromara/hertzbeat/issues/I7ZDSM#note_21831511

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
