### PR TITLE
add an explicit tag filter

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -74,14 +74,14 @@
       [(ngModel)]="filterContent"
     />
     <input
-          style="margin-right: 5px; float: right; width: 90px; border-radius: 9px; text-align: center"
-          nz-input
-          type="text"
-          [placeholder]="'monitors.search.tag' | i18n"
-          nzSize="default"
-          (keyup.enter)="onFilterSearchMonitors()"
-          [(ngModel)]="tag"
-        />
+      style="margin-right: 5px; float: right; width: 90px; border-radius: 9px; text-align: center"
+      nz-input
+      type="text"
+      [placeholder]="'monitors.search.tag' | i18n"
+      nzSize="default"
+      (keyup.enter)="onFilterSearchMonitors()"
+      [(ngModel)]="tag"
+    />
     <nz-select
       style="margin-right: 10px; float: right"
       nzAllowClear

--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -65,7 +65,7 @@
       {{ 'common.search' | i18n }}
     </button>
     <input
-      style="margin-right: 5px; float: right; width: 200px; border-radius: 9px; text-align: center"
+      style="margin-right: 5px; float: right; width: 180px; border-radius: 9px; text-align: center"
       nz-input
       type="text"
       [placeholder]="'monitors.search.placeholder' | i18n"
@@ -73,6 +73,15 @@
       (keyup.enter)="onFilterSearchMonitors()"
       [(ngModel)]="filterContent"
     />
+    <input
+          style="margin-right: 5px; float: right; width: 90px; border-radius: 9px; text-align: center"
+          nz-input
+          type="text"
+          [placeholder]="'monitors.search.tag' | i18n"
+          nzSize="default"
+          (keyup.enter)="onFilterSearchMonitors()"
+          [(ngModel)]="tag"
+        />
     <nz-select
       style="margin-right: 10px; float: right"
       nzAllowClear
@@ -84,6 +93,7 @@
       <nz-option [nzLabel]="'monitor.status.unavailable' | i18n" nzValue="2"></nz-option>
       <nz-option [nzLabel]="'monitor.status.un-manage' | i18n" nzValue="0"></nz-option>
     </nz-select>
+
   </div>
 </div>
 

--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -93,7 +93,6 @@
       <nz-option [nzLabel]="'monitor.status.unavailable' | i18n" nzValue="2"></nz-option>
       <nz-option [nzLabel]="'monitor.status.un-manage' | i18n" nzValue="0"></nz-option>
     </nz-select>
-
   </div>
 </div>
 

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -353,6 +353,7 @@
   "monitors.import": "Import Monitor",
   "monitors.search.placeholder": "Search Monitor",
   "monitors.search.filter": "Monitor Status",
+  "monitors.search.tag": "Tag Filter",
   "monitors.total": "Total",
   "monitors.advanced": "Advanced",
   "monitors.advanced.tip": "Setting Advanced Param",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -354,6 +354,7 @@
   "monitors.import": "导入监控",
   "monitors.search.placeholder": "搜索监控",
   "monitors.search.filter": "监控状态",
+  "monitors.search.tag": "标签筛选",
   "monitors.total": "总量",
   "monitors.advanced": "高级设置",
   "monitors.advanced.tip": "设置高级可选参数",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -353,6 +353,7 @@
   "monitors.import": "導入監控",
   "monitors.search.placeholder": "搜索監控",
   "monitors.search.filter": "監控狀態",
+  "monitors.search.tag": "標籤篩選",
   "monitors.total": "總量",
   "monitors.advanced": "高級設置",
   "monitors.advanced.tip": "設置高級可選參數",


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

add an explicit tag filter. 

<img width="562" alt="截屏2023-10-29 22 32 26" src="https://github.com/dromara/hertzbeat/assets/55838224/4355986b-7a4e-450b-9353-84a8583aa5f7">

This may help users notice the tag filter feature more easily.
from issue #776 which I forgot about half a year ago.

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
