### PR TITLE
[doc] update kafka help doc

### DIFF
--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kafka.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kafka.md
@@ -18,7 +18,7 @@ keywords: [开源监控系统, 开源消息中间件监控, Kafka监控]
 2. 修改 Kafka 启动脚本
 
 修改 Kafka 安装目录下的启动脚本 `/bin/kafka-server-start.sh`    
-在倒数第二行添加如下内容, ⚠️注意替换您自己的端口和对外 IP 地址  
+在脚本正文（即非注释行）的第一行前添加如下内容, ⚠️注意替换您自己的端口和对外 IP 地址  
 
 ```shell
 export JMX_PORT=9999;


### PR DESCRIPTION
在脚本的倒数第二行前添加JMX命令无效，在正文第一行就生效

## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
