### PR TITLE
Fix flaky test in CollectUtilTest

### DIFF
--- a/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java
+++ b/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java
@@ -13,12 +13,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test case for {@link CollectUtil}
  */
 class CollectUtilTest {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
@@ -79,7 +85,7 @@ class CollectUtilTest {
     }
 
     @Test
-    void replaceCryPlaceholder() {
+    void replaceCryPlaceholder() throws JsonMappingException, JsonProcessingException {
         Metrics metrics = Metrics.builder().name("^o^name^o^").build();
         JsonElement jsonElement = new Gson().toJsonTree(metrics);
         Map<String, Configmap> configmap = new HashMap<>();
@@ -89,8 +95,7 @@ class CollectUtilTest {
 
         Metrics metricsTarget = Metrics.builder().name("张三").build();
         JsonElement jsonElementTarget = new Gson().toJsonTree(metricsTarget);
-        assertEquals(jsonElementTarget.toString(), res1.toString());
-
+        assertEquals(JSON_MAPPER.readTree(jsonElementTarget.toString()), JSON_MAPPER.readTree(res1.toString()));
 
         List<Metrics> metricsList = new ArrayList<>();
         metricsList.add(metrics);
@@ -102,7 +107,7 @@ class CollectUtilTest {
         metricsListTarget.add(metricsTarget);
         metricsListTarget.add(metricsTarget);
         JsonElement jsonArrayTarget = new Gson().toJsonTree(metricsListTarget);
-        assertEquals(jsonArrayTarget.toString(), res2.toString());
+        assertEquals(JSON_MAPPER.readTree(jsonArrayTarget.toString()), JSON_MAPPER.readTree(res2.toString()));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Use JSON_MAPPER.readTree() to compare two JSON strings instead of direct assertion to fix a flaky test

**Flaky test case:**  ```org.dromara.hertzbeat.collector.util.CollectUtilTest.replaceCryPlaceholder```

https://github.com/dromara/hertzbeat/blob/ce75254b8ec18422c48c40fe61354135d08b200d/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L82

### Problem

Test ```replaceCryPlaceholder``` in ```CollectUtilTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:


```
[ERROR] Failures: 
[ERROR]   CollectUtilTest.replaceCryPlaceholder:98 expected: <{"visible":false,"name":"张三"}> but was: <{"name":"张三","visible":false}>

[ERROR] Failures: 
[ERROR]   CollectUtilTest.replaceCryPlaceholder:111 expected: <[{"name":"张三","visible":false},{"name":"张三","visible":false}]> but was: <[{"visible":false,"name":"张三"},{"visible":false,"name":"张三"}]>
```

### Root cause

In this test, two JSON strings are compared using Assert.assertEquals() in this part of the code: 

https://github.com/dromara/hertzbeat/blob/ce75254b8ec18422c48c40fe61354135d08b200d/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L92

and

https://github.com/dromara/hertzbeat/blob/ce75254b8ec18422c48c40fe61354135d08b200d/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L105

Using Assert.assertEquals() will lead to flaky tests due to mismatch in the order of properties or if there are nested structures. In this particular test case, there is a mismatch in the order of properties and therefore the assertion failed making the test flaky when tested with NonDex.

### Fix

JSON_MAPPER.readTree() for each JSON string while making the assertion to make the assertion order insensitive.

This change will not impact the code in anyways since the change is only done for the unit test.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl collector -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl collector test -Dtest=org.dromara.hertzbeat.collector.util.CollectUtilTest#replaceCryPlaceholder
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl collector edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=org.dromara.hertzbeat.collector.util.CollectUtilTest#replaceCryPlaceholder
```

NonDex test passed after the fix.


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
