### PR TITLE
Fix flaky test replaceSmilingPlaceholder

### DIFF
--- a/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java
+++ b/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java
@@ -111,7 +111,7 @@ class CollectUtilTest {
     }
 
     @Test
-    void replaceSmilingPlaceholder() {
+    void replaceSmilingPlaceholder() throws JsonMappingException, JsonProcessingException {
         Metrics metrics = Metrics.builder().name("^_^name^_^").build();
         JsonElement jsonElement = new Gson().toJsonTree(metrics);
         HashMap<String, Configmap> configmap = new HashMap<>();
@@ -120,7 +120,7 @@ class CollectUtilTest {
         JsonElement res = CollectUtil.replaceSmilingPlaceholder(jsonElement, configmap);
         Metrics metricsTarget = Metrics.builder().name("张三").build();
         JsonElement jsonElement2 = new Gson().toJsonTree(metricsTarget);
-        assertEquals(jsonElement2.toString(), res.toString());
+        assertEquals(JSON_MAPPER.readTree(jsonElement2.toString()), JSON_MAPPER.readTree(res.toString()));
 
 
         List<Metrics> metricsList = new ArrayList<>();
@@ -133,7 +133,7 @@ class CollectUtilTest {
         metricsListTarget.add(metricsTarget);
         metricsListTarget.add(metricsTarget);
         JsonElement jsonArrayTarget = new Gson().toJsonTree(metricsListTarget);
-        assertEquals(jsonArrayTarget.toString(), res2.toString());
+        assertEquals(JSON_MAPPER.readTree(jsonArrayTarget.toString()), JSON_MAPPER.readTree(res2.toString()));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Use JSON_MAPPER.readTree() to compare two JSON strings instead of direct assertion to fix a flaky test

**Flaky test case:**  ```org.dromara.hertzbeat.collector.util.CollectUtilTest.replaceSmilingPlaceholder```

https://github.com/dromara/hertzbeat/blob/7f131a179089a3a7fdd530913826c0c28e0cb5fb/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L114

### Problem

Test ```replaceSmilingPlaceholder``` in ```CollectUtilTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:


```
[ERROR] Failures: 
[ERROR]   CollectUtilTest.replaceSmilingPlaceholder:123 expected: <{"visible":false,"name":"张三"}> but was: <{"name":"张三","visible":false}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

[ERROR] Failures: 
[ERROR]   CollectUtilTest.replaceSmilingPlaceholder:136 expected: <[{"name":"张三","visible":false},{"name":"张三","visible":false}]> but was: <[{"visible":false,"name":"张三"},{"visible":false,"name":"张三"}]>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

### Root cause

In this test, two JSON strings are compared using Assert.assertEquals() in this part of the code: 

https://github.com/dromara/hertzbeat/blob/7f131a179089a3a7fdd530913826c0c28e0cb5fb/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L123

and

https://github.com/dromara/hertzbeat/blob/7f131a179089a3a7fdd530913826c0c28e0cb5fb/collector/src/test/java/org/dromara/hertzbeat/collector/util/CollectUtilTest.java#L136

Using Assert.assertEquals() will lead to flaky tests due to mismatch in the order of properties or if there are nested structures. In this particular test case, there is a mismatch in the order of properties and therefore the assertion failed making the test flaky when tested with NonDex.

### Fix

JSON_MAPPER.readTree() for each JSON string while making the assertion to make the assertion order insensitive.

This change will not impact the code in anyways since the change is only done for the unit test.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl collector -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl collector test -Dtest=org.dromara.hertzbeat.collector.util.CollectUtilTest#replaceSmilingPlaceholder
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl collector edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=org.dromara.hertzbeat.collector.util.CollectUtilTest#replaceSmilingPlaceholder
```

NonDex test passed after the fix.


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
