### PR TITLE
fix exception when sending email has special chars

### DIFF
--- a/alerter/src/main/java/org/dromara/hertzbeat/alert/util/AlertTemplateUtil.java
+++ b/alerter/src/main/java/org/dromara/hertzbeat/alert/util/AlertTemplateUtil.java
@@ -44,14 +44,14 @@ public class AlertTemplateUtil {
         }
         try {
             Matcher matcher = PATTERN.matcher(template);
-            StringBuilder buffer = new StringBuilder();
+            StringBuilder builder = new StringBuilder();
             while (matcher.find()) {
                 Object objectValue = replaceData.getOrDefault(matcher.group(1), "NullValue");
                 String value = objectValue.toString();
-                matcher.appendReplacement(buffer, value);
+                matcher.appendReplacement(builder, Matcher.quoteReplacement(value));
             }
-            matcher.appendTail(buffer);
-            return buffer.toString();
+            matcher.appendTail(builder);
+            return builder.toString();
         } catch (Exception e) {
             log.error(e.getMessage(), e);
             return template;

--- a/alerter/src/test/java/org/dromara/hertzbeat/alert/util/AlertTemplateUtilTest.java
+++ b/alerter/src/test/java/org/dromara/hertzbeat/alert/util/AlertTemplateUtilTest.java
@@ -62,4 +62,17 @@ class AlertTemplateUtilTest {
         template = "${key1} ${key2} ${key3}";
         assertEquals(AlertTemplateUtil.render(template, param), "Just for testing");
     }
+
+    @Test
+    void renderSpecialCharacters() {
+        Map<String, Object> param = new HashMap<>();
+        param.put("valueWithDollar", "$100");
+        param.put("valueWithBackslash", "C:\\Users");
+
+        String template = "The price is ${valueWithDollar} and the path is ${valueWithBackslash}";
+
+        // Expected to handle the dollar sign and backslash correctly without throwing an exception
+        String expectedResult = "The price is $100 and the path is C:\\Users";
+        assertEquals(expectedResult, AlertTemplateUtil.render(template, param));
+    }
 }


### PR DESCRIPTION
## What's changed?

1. fix (https://github.com/dromara/hertzbeat/issues/1355)
2. `Matcher.quoteReplacement(value)`会返回所有的$字符和\字符转义后的字符串，原本的`matcher.appendReplacement(buffer, value);` 将value字符串直接作为替换文本，蛋value中包含了正则表达式的引用符号（比如$1, $2等表示捕获组的内容），或者有反斜线\（用于转义的），它们将被Matcher类处理为特殊的元字符。这可能导致Illegal group reference错误
3. 此外并且没有高并发情况把StringBuffer修改为StringBuilder。
4. 增加测试用例，并且测试用例已经通过。

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.
