### PR TITLE
[Task-1386] When adding tags in tag management, random colors are given by default.

### DIFF
--- a/web-app/src/app/pojo/Tag.ts
+++ b/web-app/src/app/pojo/Tag.ts
@@ -11,6 +11,8 @@ export class Tag {
   gmtUpdate!: number;
 
   private getRandomColor(): string {
-    return '#' + Array.from({ length: 6 }, () => '0123456789ABCDEF'[Math.floor(Math.random() * 16)]).join('');
+    const colorArray = Array.from({ length: 6 }, () => '0123456789ABCDEF'[Math.floor(Math.random() * 16)]);
+    const colorCode = `#${colorArray.join('')}`;
+    return colorCode;
   }
 }

--- a/web-app/src/app/pojo/Tag.ts
+++ b/web-app/src/app/pojo/Tag.ts
@@ -10,8 +10,7 @@ export class Tag {
   gmtCreate!: number;
   gmtUpdate!: number;
 
-
   private getRandomColor(): string {
     return '#' + Array.from({ length: 6 }, () => '0123456789ABCDEF'[Math.floor(Math.random() * 16)]).join('');
-}
+  }
 }

--- a/web-app/src/app/pojo/Tag.ts
+++ b/web-app/src/app/pojo/Tag.ts
@@ -2,11 +2,16 @@ export class Tag {
   id!: number;
   name!: string;
   value!: string;
-  color: string = '#ff4081';
+  color: string = this.getRandomColor();
   // 标记类型 0:监控自动生成(monitorId,monitorName) 1: 用户生成 2: 系统预置
   type!: number;
   creator!: string;
   modifier!: string;
   gmtCreate!: number;
   gmtUpdate!: number;
+
+
+  private getRandomColor(): string {
+    return '#' + Array.from({ length: 6 }, () => '0123456789ABCDEF'[Math.floor(Math.random() * 16)]).join('');
+}
 }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
Whenever we add a new tag from a the Tag Management, a random color will be given by default to that Tag
![image](https://github.com/dromara/hertzbeat/assets/51995525/6563fb1b-4a3c-4118-a4a8-65b85f0cf7c8)
## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [X]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [X]  I have written the necessary doc or comment.
- [X]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [X] I have added the necessary [e2e tests](../e2e) and all cases have passed.
