### PR TITLE
support all ssh connect key exchange

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
@@ -1,10 +1,16 @@
 package org.dromara.hertzbeat.collector.collect.common.ssh;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.sshd.client.ClientBuilder;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.keyverifier.AcceptAllServerKeyVerifier;
+import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.common.kex.BuiltinDHFactories;
+import org.apache.sshd.common.signature.BuiltinSignatures;
 import org.apache.sshd.core.CoreModuleProperties;
+
+import java.util.ArrayList;
 
 /**
  * common ssh pool client
@@ -27,6 +33,13 @@ public class CommonSshClient {
                 SSH_CLIENT, CoreModuleProperties.HEARTBEAT_REPLY_WAIT.getName(), 300_000);
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.SOCKET_KEEPALIVE.getName(), true);
+        // set support all KeyExchange
+        SSH_CLIENT.setKeyExchangeFactories(NamedFactory.setUpTransformedFactories(
+                false,
+                BuiltinDHFactories.VALUES,
+                ClientBuilder.DH2KEX
+        ));
+        SSH_CLIENT.setSignatureFactories(new ArrayList<>(BuiltinSignatures.VALUES));
         SSH_CLIENT.start();
     }
 


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

support all ssh connect key exchange
fix: Unable to negotiate key exchange for KEX algorithms (client: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group18-sha512,diffie-hellman-group17-sha512,diffie-hellman-group16-sha512,diffie-hellman-group15-sha512,diffie-hellman-group14-sha256 / server: diffie-hellman-group1-sha1,diffie-hellman-group14-sha1)

/close https://github.com/dromara/hertzbeat/issues/1375


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
