### PR TITLE
bugfix delete monitor error after monitor canceled

### DIFF
--- a/manager/src/main/java/org/dromara/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/manager/src/main/java/org/dromara/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -652,7 +652,6 @@ public class MonitorServiceImpl implements MonitorService {
         if (!managedMonitors.isEmpty()) {
             for (Monitor monitor : managedMonitors) {
                 collectJobScheduling.cancelAsyncCollectJob(monitor.getJobId());
-                monitor.setJobId(null);
             }
             monitorDao.saveAll(managedMonitors);
         }


### PR DESCRIPTION
取消监控cancelManageMonitors方法：删除设置jobId为空。否则取消监控后，无法删除该监控项。
jobId保留可以等待下次开启监控时复用该jobId，不影响其他功能。