### PR TITLE
bugfix history range query not work when victoria-metrics store

### DIFF
--- a/warehouse/src/main/java/org/dromara/hertzbeat/warehouse/store/HistoryVictoriaMetricsDataStorage.java
+++ b/warehouse/src/main/java/org/dromara/hertzbeat/warehouse/store/HistoryVictoriaMetricsDataStorage.java
@@ -221,6 +221,8 @@ public class HistoryVictoriaMetricsDataStorage extends AbstractHistoryDataStorag
             HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
             URI uri = UriComponentsBuilder.fromHttpUrl(victoriaMetricsProp.getUrl() + EXPORT_PATH)
                     .queryParam(URLEncoder.encode("match[]", StandardCharsets.UTF_8), URLEncoder.encode("{" + timeSeriesSelector + "}", StandardCharsets.UTF_8))
+                    .queryParam("start", URLEncoder.encode("now-" + history, StandardCharsets.UTF_8))
+                    .queryParam("end", "now")
                     .build(true).toUri();
             ResponseEntity<String> responseEntity = restTemplate.exchange(uri,
                     HttpMethod.GET, httpEntity, String.class);


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
