### PR TITLE
bugfix nginx collect http deadlock error

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -112,9 +112,7 @@ public class HttpCollectImpl extends AbstractCollect {
         }
         HttpContext httpContext = createHttpContext(metrics.getHttp());
         HttpUriRequest request = createHttpRequest(metrics.getHttp());
-        try {
-            CloseableHttpResponse response = CommonHttpClient.getHttpClient()
-                                                     .execute(request, httpContext);
+        try (CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(request, httpContext)) {
             int statusCode = response.getStatusLine().getStatusCode();
             boolean isSuccessInvoke = checkSuccessInvoke(metrics, statusCode);
             log.debug("http response status: {}", statusCode);

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/nginx/NginxCollectImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/nginx/NginxCollectImpl.java
@@ -81,10 +81,8 @@ public class NginxCollectImpl extends AbstractCollect {
 
         HttpContext httpContext = createHttpContext(metrics.getNginx());
         HttpUriRequest request = createHttpRequest(metrics.getNginx());
-        try {
+        try (CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(request, httpContext)){
             // 发起http请求，获取响应数据
-            CloseableHttpResponse response = CommonHttpClient.getHttpClient()
-                    .execute(request, httpContext);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != SUCCESS_CODE) {
                 builder.setCode(CollectRep.Code.FAIL);
@@ -105,6 +103,10 @@ public class NginxCollectImpl extends AbstractCollect {
             log.info(errorMsg);
             builder.setCode(CollectRep.Code.FAIL);
             builder.setMsg(errorMsg);
+        } finally {
+            if (request != null) {
+                request.abort();
+            }
         }
 
     }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

due not close the http response or `request.abort()` to returen the connection to http pool, http client pool may casue the dead lock

<img width="833" alt="image" src="https://github.com/dromara/hertzbeat/assets/24788200/8f74cd9b-d2bb-4cd3-b660-d361d746fcb8">

[stack.log](https://github.com/dromara/hertzbeat/files/13863191/stack.log)


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
