### PR TITLE
bugfix: search monitors error when pageable #1470

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -147,6 +147,31 @@ export class MonitorListComponent implements OnInit {
       }
     );
   }
+  changeMonitorTable(sortField?: string | null, sortOrder?: string | null) {
+    this.tableLoading = true;
+    let monitorInit$ = this.monitorSvc
+      .searchMonitors(this.app, this.tag, this.filterContent, this.filterStatus, this.pageIndex - 1, this.pageSize, sortField, sortOrder)
+      .subscribe(
+        message => {
+          this.tableLoading = false;
+          this.checkedAll = false;
+          this.checkedMonitorIds.clear();
+          if (message.code === 0) {
+            let page = message.data;
+            this.monitors = page.content;
+            this.pageIndex = page.number + 1;
+            this.total = page.totalElements;
+          } else {
+            console.warn(message.msg);
+          }
+          monitorInit$.unsubscribe();
+        },
+        error => {
+          this.tableLoading = false;
+          monitorInit$.unsubscribe();
+        }
+      );
+  }
 
   onEditOneMonitor(monitorId: number) {
     if (monitorId == null) {
@@ -422,7 +447,7 @@ export class MonitorListComponent implements OnInit {
     const currentSort = sort.find(item => item.value !== null);
     const sortField = (currentSort && currentSort.key) || null;
     const sortOrder = (currentSort && currentSort.value) || null;
-    this.loadMonitorTable(sortField, sortOrder);
+    this.changeMonitorTable(sortField, sortOrder);
   }
 
   protected readonly sliceTagName = formatTagName;

--- a/web-app/src/app/service/monitor.service.ts
+++ b/web-app/src/app/service/monitor.service.ts
@@ -129,7 +129,9 @@ export class MonitorService {
     searchValue: string,
     status: number,
     pageIndex: number,
-    pageSize: number
+    pageSize: number,
+    sortField?: string | null,
+    sortOrder?: string | null
   ): Observable<Message<Page<Monitor>>> {
     pageIndex = pageIndex ? pageIndex : 0;
     pageSize = pageSize ? pageSize : 8;
@@ -147,6 +149,12 @@ export class MonitorService {
     }
     if (app != undefined) {
       httpParams = httpParams.append('app', app);
+    }
+    if (sortField != null && sortOrder != null) {
+      httpParams = httpParams.appendAll({
+        sort: sortField,
+        order: sortOrder == 'ascend' ? 'asc' : 'desc'
+      });
     }
     if (searchValue != undefined && searchValue != '' && searchValue.trim() != '') {
       httpParams = httpParams.append('name', searchValue);


### PR DESCRIPTION
## What's changed?


I've added a new function, changeMonitorTable, so that it can be paginated after search and still carry parameters.

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
