### PR TITLE
bugfix prometheus type metrics threshold alarm not work

### DIFF
--- a/alerter/src/main/java/org/dromara/hertzbeat/alert/calculate/CalculateAlarm.java
+++ b/alerter/src/main/java/org/dromara/hertzbeat/alert/calculate/CalculateAlarm.java
@@ -132,6 +132,9 @@ public class CalculateAlarm {
         long currentTimeMilli = System.currentTimeMillis();
         long monitorId = metricsData.getId();
         String app = metricsData.getApp();
+        if (app.startsWith(CommonConstants.PROMETHEUS_APP_PREFIX)) {
+            app = CommonConstants.PROMETHEUS;
+        }
         String metrics = metricsData.getMetrics();
         // If the metrics whose scheduling priority is 0 has the status of collecting response data UN_REACHABLE/UN_CONNECTABLE,
         // the highest severity alarm is generated to monitor the status change


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

bugfix prometheus type metrics threshold alarm not work

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
