### PR TITLE
Feature: http_sd monitor

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -179,6 +179,19 @@
             <artifactId>dnsjava</artifactId>
             <version>3.5.2</version>
         </dependency>
+
+        <!-- consul -->
+        <dependency>
+            <groupId>com.ecwid.consul</groupId>
+            <artifactId>consul-api</artifactId>
+            <version>1.4.5</version>
+        </dependency>
+        <!-- nacos -->
+        <dependency>
+            <groupId>com.alibaba.nacos</groupId>
+            <artifactId>nacos-client</artifactId>
+            <version>2.2.1</version>
+        </dependency>
     </dependencies>
     
     <profiles>

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/HttpsdImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/HttpsdImpl.java
@@ -1,0 +1,95 @@
+package org.dromara.hertzbeat.collector.collect.httpsd;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.dromara.hertzbeat.collector.collect.AbstractCollect;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ConnectConfig;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClient;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClientManagement;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServerInfo;
+import org.dromara.hertzbeat.collector.dispatch.DispatchConstants;
+import org.dromara.hertzbeat.common.constants.CollectorConstants;
+import org.dromara.hertzbeat.common.constants.CommonConstants;
+import org.dromara.hertzbeat.common.entity.job.Metrics;
+import org.dromara.hertzbeat.common.entity.job.protocol.HttpsdProtocol;
+import org.dromara.hertzbeat.common.entity.message.CollectRep;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+/**
+ * http_sd protocol collection implementation
+ * @author Calvin
+ */
+@Slf4j
+public class HttpsdImpl extends AbstractCollect {
+    private final static String SERVER = "server";
+    private final DiscoveryClientManagement discoveryClientManagement = new DiscoveryClientManagement();
+
+    @Override
+    public void collect(CollectRep.MetricsData.Builder builder, long monitorId, String app, Metrics metrics) {
+        HttpsdProtocol httpsdProtocol = metrics.getHttpsd();
+        // check params
+        if (checkParamsFailed(httpsdProtocol)) {
+            builder.setCode(CollectRep.Code.FAIL);
+            builder.setMsg("http_sd collect must have a valid http_sd protocol param! ");
+            return;
+        }
+
+        long beginTime = System.currentTimeMillis();
+
+        try (DiscoveryClient discoveryClient = discoveryClientManagement.getClient(httpsdProtocol)) {
+            collectMetrics(builder, metrics, beginTime, discoveryClient);
+        }catch (Exception exception) {
+            log.error("Failed to connect server by discovery client or get instance info...");
+        }
+    }
+
+    private void collectMetrics(CollectRep.MetricsData.Builder builder, Metrics metrics, long beginTime, DiscoveryClient discoveryClient) {
+        // Available and Server monitor
+        if (StringUtils.equals(metrics.getName(), SERVER)) {
+            CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
+            ServerInfo serverInfo = discoveryClient.getServerInfo();
+            metrics.getAliasFields().forEach(fieldName -> {
+                if (StringUtils.equalsAnyIgnoreCase(CollectorConstants.RESPONSE_TIME, fieldName)) {
+                    valueRowBuilder.addColumns(String.valueOf(System.currentTimeMillis() - beginTime));
+                }else {
+                    addColumnIfMatched(fieldName, serverInfo, valueRowBuilder);
+                }
+            });
+
+            builder.addValues(valueRowBuilder.build());
+        }else {
+            // Service instances monitor
+            discoveryClient.getServices().forEach(serviceInstance -> {
+                CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
+                metrics.getAliasFields().forEach(fieldName -> addColumnIfMatched(fieldName, serviceInstance, valueRowBuilder));
+                builder.addValues(valueRowBuilder.build());
+            });
+        }
+    }
+
+    @Override
+    public String supportProtocol() {
+        return DispatchConstants.PROTOCOL_HTTP_SD;
+    }
+
+    private boolean checkParamsFailed(HttpsdProtocol httpsd) {
+        return Objects.isNull(httpsd) || httpsd.isInvalid();
+    }
+
+    private void addColumnIfMatched(String fieldName, Object sourceObj, CollectRep.ValueRow.Builder valueRowBuilder) {
+        String columnValue = null;
+        try {
+            Field declaredField = sourceObj.getClass().getDeclaredField(fieldName);
+            declaredField.setAccessible(Boolean.TRUE);
+            columnValue = (String) declaredField.get(sourceObj);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            log.warn("No such field for {}", fieldName);
+        }
+
+        valueRowBuilder.addColumns(StringUtils.isBlank(columnValue)
+                ? CommonConstants.NULL_VALUE
+                : columnValue);
+    }
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/HttpsdImpl.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/HttpsdImpl.java
@@ -3,7 +3,6 @@ package org.dromara.hertzbeat.collector.collect.httpsd;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.dromara.hertzbeat.collector.collect.AbstractCollect;
-import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ConnectConfig;
 import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClient;
 import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClientManagement;
 import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServerInfo;

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/constant/DiscoveryClientInstance.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/constant/DiscoveryClientInstance.java
@@ -1,0 +1,29 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.constant;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+
+/**
+ * Discovery Client Instance Name For Httpsd monitor
+ * @author Calvin
+ */
+public enum DiscoveryClientInstance {
+    CONSUL("Consul"),
+    NACOS("Nacos"),
+    NOT_SUPPORT("Not support discovery client instance! "),
+    ;
+
+    private final String name;
+
+    DiscoveryClientInstance(String name) {
+        this.name = name;
+    }
+
+    public static DiscoveryClientInstance getByName(String clientInstanceName) {
+        return Arrays.stream(DiscoveryClientInstance.values())
+                .filter(instance -> StringUtils.equalsIgnoreCase(instance.name, clientInstanceName))
+                .findFirst()
+                .orElse(DiscoveryClientInstance.NOT_SUPPORT);
+    }
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ConnectConfig.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ConnectConfig.java
@@ -1,0 +1,17 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Discovery Client Connect Config
+ * @author Calvin
+ */
+@Data
+@Builder
+@AllArgsConstructor
+public class ConnectConfig {
+    private String host;
+    private int port;
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/DiscoveryClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/DiscoveryClient.java
@@ -1,0 +1,18 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery;
+
+import org.dromara.hertzbeat.common.entity.job.protocol.HttpsdProtocol;
+
+import java.util.List;
+
+/**
+ * @author Calvin
+ */
+public interface DiscoveryClient extends AutoCloseable {
+    ConnectConfig buildConnectConfig(HttpsdProtocol httpsdProtocol);
+
+    void connect(ConnectConfig connectConfig);
+
+    ServerInfo getServerInfo();
+
+    List<ServiceInstance> getServices();
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/DiscoveryClientManagement.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/DiscoveryClientManagement.java
@@ -1,0 +1,43 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery;
+
+import org.dromara.hertzbeat.collector.collect.httpsd.constant.DiscoveryClientInstance;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.impl.ConsulDiscoveryClient;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.impl.NacosDiscoveryClient;
+import org.dromara.hertzbeat.common.entity.job.protocol.HttpsdProtocol;
+
+import java.util.Objects;
+
+/**
+ * @author Calvin
+ */
+public class DiscoveryClientManagement {
+
+    public DiscoveryClient getClient(HttpsdProtocol httpsdProtocol) {
+        return createClient(httpsdProtocol, DiscoveryClientInstance.getByName(httpsdProtocol.getDiscoveryClientTypeName()));
+    }
+
+    private DiscoveryClient createClient(HttpsdProtocol httpsdProtocol, DiscoveryClientInstance discoveryClientInstance) {
+        if (Objects.equals(discoveryClientInstance, DiscoveryClientInstance.NOT_SUPPORT)) {
+            return null;
+        }
+
+        return doCreateClient(httpsdProtocol, discoveryClientInstance);
+    }
+
+    private DiscoveryClient doCreateClient(HttpsdProtocol httpsdProtocol, DiscoveryClientInstance discoveryClientInstance) {
+        DiscoveryClient discoveryClient;
+        switch (discoveryClientInstance) {
+            case CONSUL:
+                discoveryClient = new ConsulDiscoveryClient();
+                break;
+            case NACOS:
+                discoveryClient = new NacosDiscoveryClient();
+                break;
+            default:
+                return null;
+        }
+
+        discoveryClient.connect(discoveryClient.buildConnectConfig(httpsdProtocol));
+        return discoveryClient;
+    }
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ServerInfo.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ServerInfo.java
@@ -1,0 +1,18 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Calvin
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ServerInfo {
+    private String address;
+    private String port;
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ServiceInstance.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/ServiceInstance.java
@@ -1,0 +1,19 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author Calvin
+ */
+@Data
+@Builder
+@AllArgsConstructor
+public class ServiceInstance {
+    private String serviceId;
+    private String serviceName;
+    private String address;
+    private String port;
+    private String healthStatus;
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/ConsulDiscoveryClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/ConsulDiscoveryClient.java
@@ -1,0 +1,77 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery.impl;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.agent.model.Check;
+import com.ecwid.consul.v1.agent.model.Self;
+import com.ecwid.consul.v1.agent.model.Service;
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ConnectConfig;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClient;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServerInfo;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServiceInstance;
+import org.dromara.hertzbeat.common.entity.job.protocol.HttpsdProtocol;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Calvin
+ */
+public class ConsulDiscoveryClient implements DiscoveryClient {
+    private ConsulClient consulClient;
+
+    @Override
+    public ConnectConfig buildConnectConfig(HttpsdProtocol httpsdProtocol) {
+        return ConnectConfig.builder()
+                .host(httpsdProtocol.getHost())
+                .port(Integer.parseInt(httpsdProtocol.getPort()))
+                .build();
+    }
+
+    @Override
+    public void connect(ConnectConfig connectConfig) {
+        consulClient = new ConsulClient(connectConfig.getHost(), connectConfig.getPort());
+    }
+
+    @Override
+    public ServerInfo getServerInfo() {
+        Self self = consulClient.getAgentSelf().getValue();
+        return ServerInfo.builder()
+                .address(self.getMember().getAddress())
+                .port(String.valueOf(self.getMember().getPort()))
+                .build();
+    }
+
+    @Override
+    public List<ServiceInstance> getServices() {
+        Map<String, Service> serviceMap = consulClient.getAgentServices().getValue();
+        List<ServiceInstance> serviceInstanceList = Lists.newArrayListWithExpectedSize(serviceMap.size());
+        Collection<Check> healthCheckList = consulClient.getAgentChecks().getValue().values();
+
+        serviceMap.forEach((serviceId, instance) -> {
+            serviceInstanceList.add(ServiceInstance.builder()
+                    .serviceId(serviceId)
+                    .serviceName(instance.getService())
+                    .address(instance.getAddress())
+                    .port(String.valueOf(instance.getPort()))
+                    .healthStatus(getHealthStatus(serviceId, healthCheckList))
+                    .build());
+        });
+
+        return serviceInstanceList;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private String getHealthStatus(String serviceId, Collection<Check> healthCheckList) {
+        return healthCheckList.stream()
+                .filter(healthCheck -> StringUtils.equals(healthCheck.getServiceId(), serviceId))
+                .findFirst()
+                .map(check -> check.getStatus().name())
+                .orElse("");
+    }
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/ConsulDiscoveryClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/ConsulDiscoveryClient.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * DiscoveryClient impl of Consul
  * @author Calvin
  */
 public class ConsulDiscoveryClient implements DiscoveryClient {

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/NacosDiscoveryClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/NacosDiscoveryClient.java
@@ -14,6 +14,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * DiscoveryClient impl of Nacos
+ * @author Calvin
+ */
 public class NacosDiscoveryClient implements DiscoveryClient {
     private NamingService namingService;
     private ConnectConfig localConnectConfig;

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/NacosDiscoveryClient.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/httpsd/discovery/impl/NacosDiscoveryClient.java
@@ -1,0 +1,87 @@
+package org.dromara.hertzbeat.collector.collect.httpsd.discovery.impl;
+
+import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.api.naming.NamingFactory;
+import com.alibaba.nacos.api.naming.NamingService;
+import com.google.common.collect.Lists;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ConnectConfig;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClient;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServerInfo;
+import org.dromara.hertzbeat.collector.collect.httpsd.discovery.ServiceInstance;
+import org.dromara.hertzbeat.common.entity.job.protocol.HttpsdProtocol;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class NacosDiscoveryClient implements DiscoveryClient {
+    private NamingService namingService;
+    private ConnectConfig localConnectConfig;
+
+    @Override
+    public ConnectConfig buildConnectConfig(HttpsdProtocol httpsdProtocol) {
+        return ConnectConfig.builder()
+                .host(httpsdProtocol.getHost())
+                .port(Integer.parseInt(httpsdProtocol.getPort()))
+                .build();
+    }
+
+    @Override
+    public void connect(ConnectConfig connectConfig) {
+        try {
+            localConnectConfig = connectConfig;
+            namingService = NamingFactory.createNamingService(connectConfig.getHost() + ":" + connectConfig.getPort());
+        }catch (NacosException exception) {
+            throw new RuntimeException("Failed to init namingService");
+        }
+    }
+
+    @Override
+    public ServerInfo getServerInfo() {
+        if (Objects.isNull(namingService)) {
+            return new ServerInfo();
+        }
+
+        return ServerInfo.builder()
+                .address(localConnectConfig.getHost())
+                .port(String.valueOf(localConnectConfig.getPort()))
+                .build();
+    }
+
+    @Override
+    public List<ServiceInstance> getServices() {
+        if (Objects.isNull(namingService)) {
+            return Collections.emptyList();
+        }
+
+        List<ServiceInstance> serviceInstanceList = Lists.newArrayList();
+        try {
+            for (String serviceName : namingService.getServicesOfServer(0, 9999).getData()) {
+                namingService.getAllInstances(serviceName).forEach(instance ->
+                        serviceInstanceList.add(ServiceInstance.builder()
+                                .serviceId(instance.getInstanceId())
+                                .serviceName(instance.getServiceName())
+                                .address(instance.getIp())
+                                .port(String.valueOf(instance.getPort()))
+                                .healthStatus(instance.isHealthy() ? "UP" : "DOWN")
+                                .build()));
+            }
+        } catch (NacosException e) {
+            throw new RuntimeException("Failed to fetch instance info");
+        }
+
+        return serviceInstanceList;
+    }
+
+    @Override
+    public void close() {
+        if (namingService == null) {
+            return;
+        }
+
+        try {
+            namingService.shutDown();
+        }catch (NacosException ignore) {
+        }
+    }
+}

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/dispatch/DispatchConstants.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/dispatch/DispatchConstants.java
@@ -115,6 +115,10 @@ public interface DispatchConstants {
      * protocol pop3
      */
     String PROTOCOL_POP3 = "pop3";
+    /**
+     * protocol http_sd
+     */
+    String PROTOCOL_HTTP_SD = "httpsd";
 
     // Protocol type related - end
     // 协议类型相关 - end //

--- a/collector/src/main/resources/META-INF/services/org.dromara.hertzbeat.collector.collect.AbstractCollect
+++ b/collector/src/main/resources/META-INF/services/org.dromara.hertzbeat.collector.collect.AbstractCollect
@@ -20,3 +20,4 @@ org.dromara.hertzbeat.collector.collect.nginx.NginxCollectImpl
 org.dromara.hertzbeat.collector.collect.memcached.MemcachedCollectImpl
 org.dromara.hertzbeat.collector.collect.nebulagraph.NebulaGraphCollectImpl
 org.dromara.hertzbeat.collector.collect.pop3.Pop3CollectImpl
+org.dromara.hertzbeat.collector.collect.httpsd.HttpsdImpl

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Metrics.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/job/Metrics.java
@@ -204,6 +204,10 @@ public class Metrics {
      * Monitoring configuration information using the public Nginx protocol
      */
     private Pop3Protocol pop3;
+    /**
+     * Monitoring configuration information using the public http_sd protocol
+     */
+    private HttpsdProtocol httpsd;
 
     /**
      * collector use - Temporarily store subTask metrics response data

--- a/common/src/main/java/org/dromara/hertzbeat/common/entity/job/protocol/HttpsdProtocol.java
+++ b/common/src/main/java/org/dromara/hertzbeat/common/entity/job/protocol/HttpsdProtocol.java
@@ -1,0 +1,24 @@
+package org.dromara.hertzbeat.common.entity.job.protocol;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Calvin
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HttpsdProtocol {
+    private String host;
+    private String port;
+    private String discoveryClientTypeName;
+
+    public boolean isInvalid() {
+        return StringUtils.isAnyBlank(host, port, discoveryClientTypeName);
+    }
+}

--- a/home/docs/help/http_sd.md
+++ b/home/docs/help/http_sd.md
@@ -33,30 +33,22 @@ keywords: [open source monitoring tool, open source java monitoring tool, monito
 
 # Collection Metrics
 
-#### Metrics Set：nginx_status
+## Metrics Set：server
 
-| Metric name | Metric unit | Metric help description                  |
-|-------------|-------------|------------------------------------------|
-| accepts     |             | Accepted connections                     |
-| handled     |             | Successfully processed connections       |
-| active      |             | Currently active connections             |
-| dropped     |             | Discarded connections                    |
-| requests    |             | Client requests                          |
-| reading     |             | Connections performing read operations   |
-| writing     |             | Connections performing write operations  |
-| waiting     |             | Waiting connections                      |
+| Metric name   | Metric unit | Metric help description |
+| ------------- | ----------- | ----------------------- |
+| Address       |             |                         |
+| Port          |             |                         |
+| Response Time | ms          |                         |
 
-#### Metrics Set：req_status
+## Metrics Set：service
 
-| Metric name | Metric unit | Metric help description         |
-|-------------|-------------|---------------------------------|
-| zone_name   |             | Group category                  |
-| key         |             | Group name                      |
-| max_active  |             | Maximum concurrent connections  |
-| max_bw      | kb          | Maximum bandwidth               |
-| traffic     | kb          | Total traffic                   |
-| requests    |             | Total requests                  |
-| active      |             | Current concurrent connections  |
-| bandwidth   | kb          | Current bandwidth               |
+| Metric name   | Metric unit | Metric help description          |
+| ------------- | ----------- | -------------------------------- |
+| Service Id    |             |                                  |
+| Service Name  |             |                                  |
+| Address       |             |                                  |
+| Port          |             |                                  |
+| Health Status |             | Current health status of service |
 
 

--- a/home/docs/help/http_sd.md
+++ b/home/docs/help/http_sd.md
@@ -1,0 +1,62 @@
+---
+id: httpsd
+title: Monitoring Httpsd
+sidebar_label: Httpsd Monitor
+keywords: [open source monitoring tool, open source java monitoring tool, monitoring httpsd metrics]
+---
+
+> Collect and monitor the general performance Metrics of Httpsd.
+
+**Protocol Use：httpsd**
+
+# Steps to monitor micro services
+
+1. Make sure your **Register center** is available
+
+   > We currently support for `Consul` and `Nacos`.
+
+2. Add http_sd monitor and enter necessary info about **Register center** on Hertzbeat, such as host, port and so on.
+
+3. Click **OK**
+
+# Configuration parameter
+
+| Parameter name        | Parameter help description                                   |
+| --------------------- | ------------------------------------------------------------ |
+| Host                  | Monitored IPV4, IPV6 or domain name. Note⚠️Without protocol header (eg: https://, http://) |
+| Task name             | Identify the name of this monitoring. The name needs to be unique |
+| Port                  | Port provided by Register center                             |
+| Discovery Client Type | Select one Register center that you want to monitor          |
+| Collection interval   | Interval time of monitor periodic data collection, unit: second, and the minimum interval that can be set is 30 seconds |
+| Whether to detect     | Whether to detect and check the availability of monitoring before adding monitoring. Adding and modifying operations will continue only after the detection is successful |
+| Description remarks   | For more information about identifying and describing this monitoring, users can note information here |
+
+# Collection Metrics
+
+#### Metrics Set：nginx_status
+
+| Metric name | Metric unit | Metric help description                  |
+|-------------|-------------|------------------------------------------|
+| accepts     |             | Accepted connections                     |
+| handled     |             | Successfully processed connections       |
+| active      |             | Currently active connections             |
+| dropped     |             | Discarded connections                    |
+| requests    |             | Client requests                          |
+| reading     |             | Connections performing read operations   |
+| writing     |             | Connections performing write operations  |
+| waiting     |             | Waiting connections                      |
+
+#### Metrics Set：req_status
+
+| Metric name | Metric unit | Metric help description         |
+|-------------|-------------|---------------------------------|
+| zone_name   |             | Group category                  |
+| key         |             | Group name                      |
+| max_active  |             | Maximum concurrent connections  |
+| max_bw      | kb          | Maximum bandwidth               |
+| traffic     | kb          | Total traffic                   |
+| requests    |             | Total requests                  |
+| active      |             | Current concurrent connections  |
+| bandwidth   | kb          | Current bandwidth               |
+
+

--- a/manager/src/main/resources/define/app-http_sd.yml
+++ b/manager/src/main/resources/define/app-http_sd.yml
@@ -80,12 +80,8 @@ params:
     options:
       - label: Consul
         value: Consul
-      - label: Zookeeper
-        value: Zookeeper
       - label: Nacos
         value: Nacos
-      - label: Eureka
-        value: Eureka
 
 metrics:
   - name: server

--- a/manager/src/main/resources/define/app-http_sd.yml
+++ b/manager/src/main/resources/define/app-http_sd.yml
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The monitoring type category：service-application service monitoring db-database monitoring mid-middleware custom-custom monitoring os-operating system monitoring
+# 监控类型所属类别：service-应用服务 program-应用程序 db-数据库 custom-自定义 os-操作系统 bigdata-大数据 mid-中间件 webserver-web服务器 cache-缓存 cn-云原生 network-网络监控等等
+category: service
+# The monitoring type eg: linux windows tomcat mysql aws...
+# 监控类型 eg: linux windows tomcat mysql aws...
+app: httpsd
+# 监控类型国际化名称
+name:
+  zh-CN: HTTP SD监控
+  en-US: HTTP SD MONITORS
+# The description and help of this monitoring type
+# 监控类型的帮助描述信息
+help:
+  zh-CN: HertzBeat 对 HTTP SD 的相关指标进行监测。
+  en-US: HertzBeat monitors related indicators of HTTP SD.
+  zh-TW: HertzBeat對HTTP SD相關名額進行監測。
+# 监控所需输入参数定义(根据定义渲染页面UI)
+# Input params define for monitoring(render web ui by the definition)
+params:
+  # field-param field key
+  # field-字段名称标识符
+  - field: host
+    # name-param field display i18n name
+    # name-参数字段显示名称
+    name:
+      zh-CN: Host
+      en-US: Host
+    # type-param field type(most mapping the html input type)
+    # type-字段类型,样式(大部分映射input标签type属性)
+    type: host
+    # required-true or false
+    # 是否是必输项 true-必填 false-可选
+    required: true
+  # field-param field key
+  # field-字段名称标识符
+  - field: port
+    # name-param field display i18n name
+    # name-参数字段显示名称
+    name:
+      zh-CN: 端口
+      en-US: Port
+    # type-param field type(most mapping the html input type)
+    # type-字段类型,样式(大部分映射input标签type属性)
+    type: number
+    # when type is number, range is required
+    # 当type为number时,用range表示范围
+    range: '[0,65535]'
+    # required-true or false
+    # 是否是必输项 true-必填 false-可选
+    required: true
+  - field: discoveryClientTypeName
+    # name-param field display i18n name
+    # name-参数字段显示名称
+    name:
+      zh-CN: 注册中心类型
+      en-US: Discovery Client Type
+    # type-param field type(most mapping the html input type)
+    # type-字段类型,样式(大部分映射input标签type属性)
+    type: radio
+    # required-true or false
+    # required-是否是必输项 true-必填 false-可选
+    required: true
+    # when type is radio checkbox, use option to show optional values {name1:value1,name2:value2}
+    # 当type为radio单选框, checkbox复选框时, option表示可选项值列表 {name1:value1,name2:value2}
+    options:
+      - label: Consul
+        value: Consul
+      - label: Zookeeper
+        value: Zookeeper
+      - label: Nacos
+        value: Nacos
+      - label: Eureka
+        value: Eureka
+
+metrics:
+  - name: server
+    i18n:
+      zh-CN: 注册中心信息
+      en-US: Discovery Client Info
+    priority: 0
+    fields:
+      - field: address
+        type: 1
+        i18n:
+          zh-CN: 注册中心地址
+          en-US: Address
+      - field: port
+        type: 1
+        i18n:
+          zh-CN: 注册中心端口
+          en-US: Port
+      - field: responseTime
+        type: 0
+        unit: ms
+        i18n:
+          zh-CN: 响应时间
+          en-US: Response Time
+    protocol: httpsd
+    httpsd:
+      host: ^_^host^_^
+      port: ^_^port^_^
+      discoveryClientTypeName: ^_^discoveryClientTypeName^_^
+  - name: service
+    i18n:
+      zh-CN: 服务实例
+      en-US: Service Instance
+    priority: 1
+    # 指标信息 包括 field名称   type字段类型:0-number数字,1-string字符串   label-是否是指标标签字段   unit:指标单位
+    # field-metric name, type-metric type(0-number,1-string), unit-metric unit('%','ms','MB'), label-whether it is a metrics label field
+    # field-指标名称, type-指标类型(0-number数字,1-string字符串), unit-指标单位('%','ms','MB'), label-是否是指标标签字段
+    fields:
+      - field: serviceId
+        type: 1
+        label: true
+        i18n:
+          zh-CN: 服务实例id
+          en-US: Service Id
+      - field: serviceName
+        type: 1
+        i18n:
+          zh-CN: 服务实例名称
+          en-US: Service Name
+      - field: address
+        type: 1
+        i18n:
+          zh-CN: 主机地址
+          en-US: Address
+      - field: port
+        type: 0
+        i18n:
+          zh-CN: 端口
+          en-US: Port
+      - field: healthStatus
+        type: 1
+        i18n:
+          zh-CN: 服务健康状态
+          en-US: Health Status
+    protocol: httpsd
+    httpsd:
+      host: ^_^host^_^
+      port: ^_^port^_^
+      discoveryClientTypeName: ^_^discoveryClientTypeName^_^
+
+


### PR DESCRIPTION
## What's changed?
#1526 
支持Http sd监控。
因使用Spring Cloud提供的统一接口DiscoveryClient对代码改动较大，目前采用了各个注册中心原生的SDK进行监控。
> 目前只添加了最常见的两种注册中心：Consul和Nacos，如果后期需要接入更多注册中心，我开放了一个接口org.dromara.hertzbeat.collector.collect.httpsd.discovery.DiscoveryClient，直接实现该接口即可。
代码位置：
![image](https://github.com/dromara/hertzbeat/assets/131688897/01c147bb-5ce5-412b-a01c-d7b67a99a2be)


本地调试结果：
![httpsd](https://github.com/dromara/hertzbeat/assets/131688897/7fae6f37-5e40-4ce3-be94-401c31301e95)
![consul](https://github.com/dromara/hertzbeat/assets/131688897/3fd0e99d-bec9-4afe-be79-bc304ad0357e)



## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](../e2e) and all cases have passed.
