### PR TITLE
bugfix collector can not startup alone

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/Collector.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/Collector.java
@@ -21,11 +21,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
 
 /**
  * collector startup
  *
  */
+@ComponentScan(basePackages = {"org.dromara.hertzbeat"})
+@ConfigurationPropertiesScan(basePackages = {"org.dromara.hertzbeat"})
 @SpringBootApplication
 public class Collector {
     public static void main(String[] args) {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

- bugfix collector can not startup alone
- support bean scan in collector module

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
