### PR TITLE
remove mysql-oracle dependency jar from release package lib

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -110,6 +110,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!-- clickhouse -->
         <dependency>
@@ -147,10 +148,12 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!--redis-->
         <dependency>

--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/database/JdbcSpiLoader.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/database/JdbcSpiLoader.java
@@ -37,14 +37,12 @@ public class JdbcSpiLoader implements CommandLineRunner {
     public void run(String... args) throws Exception {
         log.info("start load jdbc drivers");
         try {
-            Class.forName("com.mysql.cj.jdbc.Driver");
             Class.forName("org.postgresql.Driver");
             Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
-            Class.forName("oracle.jdbc.driver.OracleDriver");
             Class.forName("dm.jdbc.driver.DmDriver");
             Class.forName("com.clickhouse.jdbc.ClickHouseDriver");
         } catch (Exception e) {
-            log.error("load jdbc error: {}", e.getMessage(), e);
+            log.error("load jdbc error: {}", e.getMessage());
         }
         log.info("end load jdbc drivers");
     }

--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -125,6 +125,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!-- email -->
         <dependency>


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

remove mysql-oracle dependency jar from release package lib
if user want to use it, please download it yourself and put it in the lib directory for use. 
`mysql-connector-java` `ojdbc8` `orai18n`

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
