### PR TITLE
bugfix can not find mysql dependency when startup

### DIFF
--- a/collector/src/main/java/org/dromara/hertzbeat/collector/collect/database/JdbcCommonCollect.java
+++ b/collector/src/main/java/org/dromara/hertzbeat/collector/collect/database/JdbcCommonCollect.java
@@ -17,7 +17,6 @@
 
 package org.dromara.hertzbeat.collector.collect.database;
 
-import com.mysql.cj.jdbc.exceptions.CommunicationsException;
 import org.dromara.hertzbeat.collector.collect.AbstractCollect;
 import org.dromara.hertzbeat.collector.collect.common.cache.CacheIdentifier;
 import org.dromara.hertzbeat.collector.collect.common.cache.ConnectionCommonCache;
@@ -100,10 +99,6 @@ public class JdbcCommonCollect extends AbstractCollect {
                     builder.setMsg("Not support database query type: " + jdbcProtocol.getQueryType());
                     break;
             }
-        } catch (CommunicationsException communicationsException) {
-            log.warn("Jdbc sql error: {}, code: {}.", communicationsException.getMessage(), communicationsException.getErrorCode());
-            builder.setCode(CollectRep.Code.UN_REACHABLE);
-            builder.setMsg("Error: " + communicationsException.getMessage() + " Code: " + communicationsException.getErrorCode());
         } catch (PSQLException psqlException) {
             // for PostgreSQL 08001
             if (CollectorConstants.POSTGRESQL_UN_REACHABLE_CODE.equals(psqlException.getSQLState())) {

--- a/e2e/compose.yaml
+++ b/e2e/compose.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.8'
 services:
   testing:
     build:


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

due mysql dependency removed in package, system can not found mysql class error when startup. 
```
2024-03-25 15:09:23 ... 3 more
2024-03-25 15:09:23 Caused by: java.lang.NoClassDefFoundError: com/mysql/cj/jdbc/exceptions/CommunicationsException
2024-03-25 15:09:23 at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
2024-03-25 15:09:23 at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3373)
2024-03-25 15:09:23 at java.base/java.lang.Class.getConstructor0(Class.java:3578)
2024-03-25 15:09:23 at java.base/java.lang.Class.getConstructor(Class.java:2271)
2024-03-25 15:09:23 at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:666)
2024-03-25 15:09:23 at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:663)
2024-03-25 15:09:23 at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
2024-03-25 15:09:23 at java.base/java.util.Ser
```

fix: remove the mysql CommunicationsException 

## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
