### PR TITLE
[bugfix] fix bug where reopening pop-up window still retained previously edited data after closing.

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -506,6 +506,9 @@ export class AlertSettingComponent implements OnInit {
   }
 
   onManageModalCancel() {
+    this.cascadeValues = [];
+    this.alertRules = [{}];
+    this.isExpr = false;
     this.isManageModalVisible = false;
   }
   onManageModalOk() {


### PR DESCRIPTION
fix bug where reopening pop-up window still retained previously edited data after closing.
[#1653](https://github.com/dromara/hertzbeat/issues/1653)
## What's changed?

This may be due to the failure to reset data objects when the page is closed, such as cascadeValues:

<img width="338" alt="f01cab06d7bc547872da23004c1d0cb" src="https://github.com/dromara/hertzbeat/assets/55646681/d8f25a92-91fd-4e9c-945e-42f3feaea28c">

And alertRules:

<img width="346" alt="0d59946ccf7614bc19f39eba09e53c5" src="https://github.com/dromara/hertzbeat/assets/55646681/cd3ebf6b-7a09-4235-92c8-4ccce89b61d3">

Reset it when closing the page, which seems to have resolved the issue for now:

```angular
  onManageModalCancel() {
    this.cascadeValues = [];
    this.alertRules = [{}];
    this.isExpr = false;
    this.isManageModalVisible = false;
  }
```

Edit page:

![image](https://github.com/dromara/hertzbeat/assets/55646681/45a593aa-e020-4ca0-bd59-22d042741256)

After closing/canceling the page:

![image](https://github.com/dromara/hertzbeat/assets/55646681/66937902-6ac7-46e6-aba2-6a19646bb92e)


## Checklist

- [x]  I hereby agree to the terms of the [HertzBeat CLA](https://gist.github.com/tomsun28/511c04e7643901cb550bb6ecc75a661b)
- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
